### PR TITLE
Add upper-floor furnishing foundation and reflow token.place in living room

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,10 @@ import {
   createJobbotTerminal,
   type JobbotTerminalBuild,
 } from './scene/structures/jobbotTerminal';
-import { createLowerFloorFurnishings } from './scene/structures/lowerFloorFurnishings';
+import {
+  createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
+} from './scene/structures/lowerFloorFurnishings';
 import {
   createLivingRoomMediaWall,
   type LivingRoomMediaWallBuild,
@@ -2284,6 +2287,19 @@ function initializeImmersiveScene(
       sourceId: assertLevelSourceId(collider.sourceId),
       sourceType: 'generatedCollider',
       purpose: 'lower-floor-furnishing',
+      role: collider.category,
+    });
+  });
+
+  const upperFloorFurnishings = createUpperFloorFurnishings();
+  upperStructureGroup.add(upperFloorFurnishings.group);
+  upperFloorFurnishings.colliders.forEach((collider) => {
+    upperFloorColliders.push(collider);
+    namedColliderDebugNames.set(collider, collider.debugName);
+    colliderSourceMetadata.set(collider, {
+      sourceId: assertLevelSourceId(collider.sourceId),
+      sourceType: collider.sourceType,
+      purpose: collider.purpose,
       role: collider.category,
     });
   });

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 18,
-      "syncNote": "Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.",
-      "sourceFingerprint": "2152c8d288227bea8b088e9da6474ee781f1b8ef24d7e55660856f67a3adb61a",
+      "syncRevision": 20,
+      "syncNote": "Upper furnishing authoring reuses lower-floor source; miniature furniture proxy remains deferred.",
+      "sourceFingerprint": "d677da73034fa4051dad6e6d86f5665bef4d226089fea84db955d505dd1ad96c",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "3d6b130cd99fb62fde66e6951c50e0f41ffd63ac13825bbb1dea1b3939c89d63"
+      "metadataFingerprint": "8f4712a7b3216166afdf2cbfb98b0909696bf22cb41829b2ab71ecec7d9b4875"
     },
     {
       "id": "environment:backyard",
@@ -521,11 +521,11 @@
         "src/scene/structures/axelNavigator.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "a4b7ec20ed601e304e3263fb5bf5517416cd2b4168d72ca99b606c2fa68f93cc",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "63f401237e2515f4289cdf4a9eabf90d17835ade28cbdf84afaa6f1d1abadd49"
+      "sourceFingerprint": "89086f102559baa055f93f88d427c1a0419da43ddbc6ec3fa9ae70cb6a0455b3",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "3e9975cf51e6b566487da029808e1d73a461c66fb653f8ca678d8698be1323da"
     },
     {
       "id": "poi:danielsmith-portfolio-table",
@@ -541,11 +541,11 @@
         "src/scene/miniature/poiProxyRegistry.ts",
         "src/scene/structures/portfolioMiniatureTable.ts"
       ],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "f7b1f1ff981a925d52760a724671676ec5f6aa70f0877d6c86151fcfefd8d6bc",
-      "proxyFingerprint": "4a4ff9e8191dc7a2877a6e047f1069ce1f8459bc37a2fa3b129819d8cb9eb40f",
-      "metadataFingerprint": "7ba0e258575aefd3e8590a2cbd714456f28a8cef0603059b339a5889a121a85a"
+      "sourceFingerprint": "f0a1fab98b8f1a5bd648de469084e8d9b19e020aaf72d3c255cec5647b3e6c91",
+      "proxyFingerprint": "4b66f989c83850fd87a6380d2c0f44e05f9e6171512e6cee0630ac9a7990272d",
+      "metadataFingerprint": "11e500391a318b1de9e1822f99a530889c1f8d9878380d1743e55c2cbbd2ae2b"
     },
     {
       "id": "poi:dspace-backyard-rocket",
@@ -556,11 +556,11 @@
         "src/scene/structures/modelRocket.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc279c5b2b65299859e87cfdef038f48cfdba1dac61fe0311a34522e700ea7c2",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "18df3400e4b42e5e5bc3f08020a44c78d4c00f4669abcb201698ad3c3d7c57da"
+      "sourceFingerprint": "c87383d3a6f49d502eb783e065ef22b959f13462848666216d3277db98321501",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "ae6a142032a853044d85591e843017c63ecb256977d2b3470a64bbadc2d455ba"
     },
     {
       "id": "poi:f2clipboard-kitchen-console",
@@ -571,11 +571,11 @@
         "src/scene/structures/f2ClipboardConsole.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
+      "syncRevision": 8,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "d338953e130bb55599de8591f7c3c585f3deccf6ad1071e42092668115c1721b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "203724c45bb66fbd270e45ab7a70e1dbafba3029e5c7564acd9d086d805da04e"
+      "sourceFingerprint": "d9c99df1cd61da12890dc0b6e14a548964dc78e8abdbea2ea974e0cfe2eb3ce4",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "0319d9587db6148b3c51b9a0332a86c100da064658bfa70dd4bbe74fb1806831"
     },
     {
       "id": "poi:flywheel-studio-flywheel",
@@ -588,11 +588,11 @@
         "src/scene/structures/flywheelEnergyNetwork.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 26,
+      "syncRevision": 27,
       "syncNote": "Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.",
-      "sourceFingerprint": "06bb38b24c96fcb832e676e9159b0e4d718b7e9a664fb0c7e272e37bdd09b03b",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "85d2e4a060cf0896c4bfb81a2abf893cd8e579324bfd51282804b81016c6931a"
+      "sourceFingerprint": "51673f968397b8576b9770c51e483dbd9df4908f34becfc97e86382f9964a284",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "4c2c5505fabcadd063ee1aa9ff7085463d5be0550d429e8a2b2e35d84ed091c5"
     },
     {
       "id": "poi:futuroptimist-living-room-tv",
@@ -603,11 +603,11 @@
         "src/scene/structures/mediaWall.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "fc41839553cb8d894adb1491561c765abff3b7e7daae6f9e090d64e23eec1567",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "c6a38e8f5c9009600682de8b5410a382c8e91c60cc27703076719b2577d50a37"
+      "sourceFingerprint": "dc0353e20df47adc0fc603239278aeb743d789f8206dfef0fa5afd3dc205dc3a",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "2de309a3b301a3ea427388588fcc71cc72a872aee9dbb7207662ff75f7a56d5a"
     },
     {
       "id": "poi:gabriel-studio-sentry",
@@ -618,11 +618,11 @@
         "src/scene/structures/gabrielSentry.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
+      "syncRevision": 8,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "5519bd57ed38839a83979ca24e37884834fd8fcef58414f43c2590aa395f445f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "e211ac43acb6c5ba1c68752d59b2710f4f99ec7cfff4ebcd119ca5008e631fc3"
+      "sourceFingerprint": "77148305c61fe9d51393213a2872dfe423e200281087d58d766be8a61b23133d",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "a9b1b6d89bfba1a9f337cd752856d00ca746536f05de7cc8dd528503bee15430"
     },
     {
       "id": "poi:gitshelves-living-room-installation",
@@ -633,11 +633,11 @@
         "src/scene/structures/gitshelves.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
+      "syncRevision": 8,
       "syncNote": "Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.",
-      "sourceFingerprint": "23d44ccb3594b8a61cd8a971ac292ab08d66bd7eea213141e96b36f44224946f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "088235cd162b79a0a99f9ce58f500e3d67358bb03db4d57b739e452775f4113a"
+      "sourceFingerprint": "a6a4d7481948a838178a30b12945d9da638262d4df7ded6620f1a9a00d80d210",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "4ee75dd4b2ec99134632e337013b876be71b11be051f851a0c6dcaf68f9064e9"
     },
     {
       "id": "poi:jobbot-studio-terminal",
@@ -648,11 +648,11 @@
         "src/scene/structures/jobbotTerminal.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1f63c8815cf2c5d8527a6c3dfff5e752b503da32e9383c959d526e2408600048",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "76917fdeea6dec76f13aaabf1477853a53a1f4b5cf6d7ad6f52cbf11d3a904ab"
+      "sourceFingerprint": "11f0a7b30d7648491804a44c0379a34f727f76661f62fab5503ef237350ee20b",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "568f11fe9d24a9c4e767645a6d2962ec4c5a7fd4e5279b33c332d8ee26a7098a"
     },
     {
       "id": "poi:markers-labels",
@@ -683,11 +683,11 @@
         "src/ui/accessibility/animationPreferences.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 20,
+      "syncRevision": 21,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "bd997161126bf1aaf8ff160e31bf7ec9dd6f3014e594b71d159710bb21d3a522",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "3f7c3d3a714c32731c7a190695983084dd1dcd5ba9fa4683271c7d82e691161c"
+      "sourceFingerprint": "2446a3daca1cbc958edb093eb97e35c61f386d919800f8d772ca239d19bf7b4f",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "30412840d94ca6abdceb7f23d932ccc84a4a7fc9f6c6aa9cd7eaeecd1cc823c6"
     },
     {
       "id": "poi:sigma-kitchen-workbench",
@@ -698,11 +698,11 @@
         "src/scene/structures/sigmaWorkbench.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 7,
+      "syncRevision": 8,
       "syncNote": "Adds the printed enclosure shell around the Sigma AI pin silhouette.",
-      "sourceFingerprint": "69151e3d9000e5e8d3c0dc2ea3b817ca6e5b008b44aa03cbe5e09026ced2f23f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "aa5a817cf4f5ca8f131522be446bec1762932a4c9d6bb42b4f537fa410bc7980"
+      "sourceFingerprint": "ae2d13695f8011c7cdd9380a518859e6d114857b8ac3217ca9b25dabbd6773a5",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "7e0fa7f0cffb2bb462a0006244a757798170c99ec98f87d40adf537841843814"
     },
     {
       "id": "poi:sugarkube-backyard-greenhouse",
@@ -713,11 +713,11 @@
         "src/scene/structures/sugarkubeDeployment.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 4,
+      "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "355927cea33ea392a2a51989ae57feef1a4d07d9744279a50b75ad82534dd234",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "99b33d83ab99a3947c933042bb53e9fd6fde4fe434c907c9494a848aa1a6494b"
+      "sourceFingerprint": "ac4eb79207c4d2f70796e6b980bb8663d2e694f42a69ce6a04bca7c371f05436",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "d4d3932a82a9d1b4cecaa46964482500d5c5ce44d395282ecbdc7f9f46e53189"
     },
     {
       "id": "poi:tokenplace-studio-cluster",
@@ -728,11 +728,11 @@
         "src/scene/structures/tokenPlaceWorkstation.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 4,
+      "syncRevision": 5,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "1699b67c0db7d55fdbc27e8e45bdd2759c0e27551ac50c9df1d04f7c258bdfef",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "93f8bc5e9d12415379e8b85f87508473db89c7f4b7329fffd1d4c5a1afd22eb1"
+      "sourceFingerprint": "f02ec6225ba49f587b5cf95fa2e9f4871e58d6328d3b123cec2972685e6f2f47",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "49f420ee38ef45078a433c0452fb64d91f2559cdc34f41c73df98ecbb5e2995b"
     },
     {
       "id": "poi:wove-kitchen-loom",
@@ -743,11 +743,11 @@
         "src/scene/structures/woveLoom.ts"
       ],
       "proxyFiles": ["src/scene/miniature/poiProxyRegistry.ts"],
-      "syncRevision": 5,
+      "syncRevision": 6,
       "syncNote": "Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.",
-      "sourceFingerprint": "b5f79bc9137af44394bd859ab1224199c7eceb279d0437385238d93de7738f4f",
-      "proxyFingerprint": "d1762a098084885fbdbdf47310da5f5f110fd00de4ac6b3208da51dea472ccc0",
-      "metadataFingerprint": "9e7ffd3304fc004d8edd7d936b328e96107bf1163e4ee2921c9fe459ad7d679e"
+      "sourceFingerprint": "47b5e6a824a3e87cdfa764593ff4c578245e579d90b1dbe83c7121d1555f263d",
+      "proxyFingerprint": "54856af449d54ef8e88b14bc03784aa371c8ddc82f96096f8a32a889e2ab12ef",
+      "metadataFingerprint": "975efc049cbe3a7775f9f8819416ed65b10aa23e39a10cec00b6c736d8615844"
     },
     {
       "id": "structure:greenhouse",

--- a/src/scene/miniature/poiProxyRegistry.ts
+++ b/src/scene/miniature/poiProxyRegistry.ts
@@ -69,7 +69,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'futuroptimist-living-room-tv',
     id: 'poi:futuroptimist-living-room-tv',
     displayName: 'Futur Optimist TV proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/mediaWall.ts'],
@@ -90,7 +90,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'flywheel-studio-flywheel',
     id: 'poi:flywheel-studio-flywheel',
     displayName: 'Flywheel proxy',
-    syncRevision: 26,
+    syncRevision: 27,
     syncNote:
       'Acknowledges Flywheel debug-state snapshot hardening while preserving the final rotor, crank, static planetary gear cluster, output shaft key mark, base, bearings, energy port, and incoming/outgoing arc hints.',
     sourceFiles: [
@@ -172,7 +172,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'jobbot-studio-terminal',
     id: 'poi:jobbot-studio-terminal',
     displayName: 'Jobbot terminal proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/jobbotTerminal.ts'],
@@ -193,7 +193,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'dspace-backyard-rocket',
     id: 'poi:dspace-backyard-rocket',
     displayName: 'dSpace rocket proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/modelRocket.ts'],
@@ -210,7 +210,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sugarkube-backyard-greenhouse',
     id: 'poi:sugarkube-backyard-greenhouse',
     displayName: 'Sugarkube deployment proxy',
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sugarkubeDeployment.ts'],
@@ -306,7 +306,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'tokenplace-studio-cluster',
     id: 'poi:tokenplace-studio-cluster',
     displayName: 'token.place workstation proxy',
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [
@@ -348,7 +348,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gabriel-studio-sentry',
     id: 'poi:gabriel-studio-sentry',
     displayName: 'Gabriel sentry proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
       'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gabrielSentry.ts'],
@@ -364,7 +364,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'f2clipboard-kitchen-console',
     id: 'poi:f2clipboard-kitchen-console',
     displayName: 'f2clipboard console proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
       'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/f2ClipboardConsole.ts'],
@@ -379,7 +379,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'axel-studio-tracker',
     id: 'poi:axel-studio-tracker',
     displayName: 'Axel tracker proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/axelNavigator.ts'],
@@ -402,7 +402,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'sigma-kitchen-workbench',
     id: 'poi:sigma-kitchen-workbench',
     displayName: 'Sigma workbench proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
       'Adds the printed enclosure shell around the Sigma AI pin silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/sigmaWorkbench.ts'],
@@ -417,7 +417,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'gitshelves-living-room-installation',
     id: 'poi:gitshelves-living-room-installation',
     displayName: 'Gitshelves proxy',
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
       'Acknowledges review polish for shared animated materials and explicit socket shadows while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/gitshelves.ts'],
@@ -433,7 +433,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'wove-kitchen-loom',
     id: 'poi:wove-kitchen-loom',
     displayName: 'Wove loom proxy',
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [...baseFiles, 'src/scene/structures/woveLoom.ts'],
@@ -448,7 +448,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     poiId: 'pr-reaper-backyard-console',
     id: 'poi:pr-reaper-backyard-console',
     displayName: 'PR Reaper holographic reaper installation proxy',
-    syncRevision: 20,
+    syncRevision: 21,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [
@@ -519,7 +519,7 @@ export const MINIATURE_POI_PROXY_REGISTRY = {
     id: 'poi:danielsmith-portfolio-table',
     displayName: 'danielsmith.io recursion boundary table proxy',
     recursionBoundary: true,
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
       'Acknowledges the Flywheel-specific performance pedestal registry update while preserving this proxy silhouette.',
     sourceFiles: [

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 18,
+    syncRevision: 20,
     syncNote:
-      'Kitchen stove cooktop part names were flattened; furniture proxy coverage remains deferred.',
+      'Upper furnishing authoring reuses lower-floor source; miniature furniture proxy remains deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/poi/placements.test.ts
+++ b/src/scene/poi/placements.test.ts
@@ -40,7 +40,7 @@ describe('applyManualPoiPlacements', () => {
         roomId: 'livingRoom',
         floorId: 'ground',
         anchorY: 0.75,
-        position: { x: -22.34, y: 0, z: -22.61 },
+        position: { x: 1.8, y: 0, z: -21.2 },
       },
       {
         id: 'sugarkube-backyard-greenhouse',

--- a/src/scene/poi/placements.ts
+++ b/src/scene/poi/placements.ts
@@ -83,13 +83,13 @@ export const MANUAL_POI_PLACEMENTS: Partial<
   },
   'tokenplace-studio-cluster': {
     roomId: 'livingRoom',
-    position: { x: -22.34, y: getFloorTopElevation('ground'), z: -22.61 },
+    position: { x: 1.8, y: getFloorTopElevation('ground'), z: -21.2 },
     interactionAnchorPosition: {
-      x: -22.34,
+      x: 1.8,
       y: getFloorStandingInteractionAnchorY('ground'),
-      z: -22.61,
+      z: -21.2,
     },
-    headingRadians: Math.PI * 0.05,
+    headingRadians: -Math.PI * 0.18,
   },
   'sugarkube-backyard-greenhouse': {
     roomId: 'livingRoom',

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -21,6 +21,19 @@ export type LowerFloorFurnishingCategory =
 
 export type LowerFloorRoomId = 'livingRoom' | 'kitchen' | 'studio' | 'backyard';
 
+export type UpperFloorRoomId =
+  | 'upperLanding'
+  | 'creatorsStudio'
+  | 'loftLibrary'
+  | 'focusPods';
+
+export type UpperFloorFurnishingCategory =
+  | 'upper-landing'
+  | 'creators-studio'
+  | 'loft-library'
+  | 'focus-pods'
+  | 'plants-lighting-decor';
+
 export interface LowerFloorFurnishingFootprint {
   width: number;
   depth: number;
@@ -76,10 +89,51 @@ export interface LowerFloorFurnishingsCreateOptions
   definitions?: readonly LowerFloorFurnishingDefinition[];
 }
 
+export type UpperFloorFurnishingDefinition = Omit<
+  LowerFloorFurnishingDefinition,
+  'category' | 'roomId'
+> & {
+  category: UpperFloorFurnishingCategory;
+  roomId: UpperFloorRoomId;
+};
+
+export interface UpperFloorFurnishingCollider extends RectCollider {
+  furnishingId: string;
+  category: UpperFloorFurnishingCategory;
+  roomId: UpperFloorRoomId;
+  floorId: 'upper';
+  sourceType: 'generatedCollider';
+  purpose: 'upper-floor-furnishing';
+  sourceId: string;
+  debugName: string;
+}
+
+export interface UpperFloorFurnishingValidationOptions {
+  roomBounds?: Partial<Record<UpperFloorRoomId, RectCollider>>;
+  reservedBlockers?: readonly RectCollider[];
+  tolerance?: number;
+}
+
+export interface UpperFloorFurnishingsCreateOptions
+  extends UpperFloorFurnishingValidationOptions {
+  definitions?: readonly UpperFloorFurnishingDefinition[];
+}
+
 export interface LowerFloorFurnishingsBuild {
   group: Group;
   colliders: LowerFloorFurnishingCollider[];
   decorativeFootprints: DecorativeFootprintRecord[];
+}
+
+export interface UpperFloorFurnishingsBuild {
+  group: Group;
+  colliders: UpperFloorFurnishingCollider[];
+  decorativeFootprints: Array<
+    Omit<DecorativeFootprintRecord, 'category' | 'roomId'> & {
+      category: UpperFloorFurnishingCategory;
+      roomId: UpperFloorRoomId;
+    }
+  >;
 }
 
 export const LOWER_FLOOR_ROOM_BOUNDS: Record<LowerFloorRoomId, RectCollider> = {
@@ -96,7 +150,7 @@ export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -22, maxX: -14, minZ: 14.8, maxZ: 17.2 },
   { minX: 11, maxX: 19, minZ: 14.8, maxZ: 17.2 },
   { minX: -32.0, maxX: -30.9, minZ: -23.2, maxZ: -16.8 },
-  { minX: -24.74, maxX: -19.94, minZ: -24.61, maxZ: -20.61 },
+  { minX: -0.6, maxX: 4.2, minZ: -23.2, maxZ: -19.2 },
   { minX: -12.34, maxX: -5.14, minZ: -26.12, maxZ: -19.72 },
   { minX: -24.0, maxX: -19.2, minZ: -0.77, maxZ: 4.03 },
   { minX: 26.4, maxX: 31.2, minZ: -24.4, maxZ: -21.2 },
@@ -106,6 +160,24 @@ export const LOWER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
   { minX: -18.5, maxX: -10.0, minZ: 18.0, maxZ: 24.2 },
   { minX: 10.0, maxX: 18.2, minZ: 22.4, maxZ: 30.4 },
 ];
+
+export const UPPER_FLOOR_ROOM_BOUNDS: Record<UpperFloorRoomId, RectCollider> = {
+  upperLanding: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+  creatorsStudio: { minX: -20, maxX: 4, minZ: -32, maxZ: 0 },
+  loftLibrary: { minX: 4, maxX: 24, minZ: -16, maxZ: 12 },
+  focusPods: { minX: -20, maxX: 24, minZ: 12, maxZ: 28 },
+};
+
+export const UPPER_FLOOR_RESERVED_BLOCKERS: readonly RectCollider[] = [
+  { minX: -18.8, maxX: -15.8, minZ: 15.6, maxZ: 18.9 },
+  { minX: -2.4, maxX: 1.2, minZ: 12.2, maxZ: 15.9 },
+  { minX: 14.8, maxX: 18.4, minZ: 16.1, maxZ: 19.4 },
+  { minX: -18.8, maxX: -15.8, minZ: -8.7, maxZ: -5.3 },
+  { minX: 5.8, maxX: 15.2, minZ: -31.2, maxZ: -24.8 },
+];
+
+export const DEFAULT_UPPER_FLOOR_FURNISHINGS: readonly UpperFloorFurnishingDefinition[] =
+  [];
 
 export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefinition[] =
   [
@@ -680,9 +752,35 @@ export function validateLowerFloorFurnishingPlan(
   definitions: readonly LowerFloorFurnishingDefinition[],
   options: LowerFloorFurnishingValidationOptions = {}
 ): void {
-  const roomBounds = { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds };
-  const blockers = options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS;
-  const tolerance = options.tolerance ?? 0.001;
+  validateFurnishingPlan(definitions, {
+    roomBounds: { ...LOWER_FLOOR_ROOM_BOUNDS, ...options.roomBounds },
+    reservedBlockers: options.reservedBlockers ?? LOWER_FLOOR_RESERVED_BLOCKERS,
+    tolerance: options.tolerance ?? 0.001,
+  });
+}
+
+function validateFurnishingPlan<
+  RoomId extends string,
+  Definition extends {
+    id: string;
+    roomId: RoomId;
+    position: { x: number; z: number };
+    orientationRadians: number;
+    solidFootprint?: LowerFloorFurnishingFootprint;
+    decorativeFootprint?: LowerFloorFurnishingFootprint;
+    solidBounds?: RectCollider;
+    decorativeBounds?: RectCollider;
+    visual?: LowerFloorFurnishingDefinition['visual'];
+  },
+>(
+  definitions: readonly Definition[],
+  options: {
+    roomBounds: Record<RoomId, RectCollider>;
+    reservedBlockers: readonly RectCollider[];
+    tolerance: number;
+  }
+): void {
+  const { roomBounds, reservedBlockers: blockers, tolerance } = options;
   definitions.forEach((definition) => {
     if (!isLevelSourceId(definition.id)) {
       throw new Error(`${definition.id} is not a valid furnishing ID.`);
@@ -831,6 +929,83 @@ export function createLowerFloorFurnishings(
 
     if (!definition.solidFootprint && !definition.decorativeFootprint) {
       furnishing.add(createVisualDetailPrimitive(definition));
+    }
+
+    group.add(furnishing);
+  });
+
+  return { group, colliders, decorativeFootprints };
+}
+
+export function validateUpperFloorFurnishingPlan(
+  definitions: readonly UpperFloorFurnishingDefinition[],
+  options: UpperFloorFurnishingValidationOptions = {}
+): void {
+  validateFurnishingPlan(definitions, {
+    roomBounds: { ...UPPER_FLOOR_ROOM_BOUNDS, ...options.roomBounds },
+    reservedBlockers: options.reservedBlockers ?? UPPER_FLOOR_RESERVED_BLOCKERS,
+    tolerance: options.tolerance ?? 0.001,
+  });
+}
+
+export function createUpperFloorFurnishings(
+  options: UpperFloorFurnishingsCreateOptions = {}
+): UpperFloorFurnishingsBuild {
+  const definitions = options.definitions ?? DEFAULT_UPPER_FLOOR_FURNISHINGS;
+  validateUpperFloorFurnishingPlan(definitions, options);
+
+  const group = new Group();
+  group.name = 'UpperFloorFurnishings';
+  const colliders: UpperFloorFurnishingCollider[] = [];
+  const decorativeFootprints: UpperFloorFurnishingsBuild['decorativeFootprints'] =
+    [];
+
+  definitions.forEach((definition) => {
+    const furnishing = new Group();
+    furnishing.name = `Furnishing:${definition.id}`;
+    furnishing.position.set(
+      definition.position.x,
+      definition.position.y ?? 0,
+      definition.position.z
+    );
+    furnishing.rotation.y = definition.orientationRadians;
+
+    const lowerCompatibleDefinition =
+      definition as unknown as LowerFloorFurnishingDefinition;
+
+    if (definition.solidFootprint) {
+      furnishing.add(createSolidPrimitive(lowerCompatibleDefinition));
+      const bounds = createRotatedAabb(definition, definition.solidFootprint);
+      colliders.push({
+        ...bounds,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        floorId: 'upper',
+        sourceType: 'generatedCollider',
+        purpose: 'upper-floor-furnishing',
+        sourceId: `upper.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        debugName: `UpperFloorFurnishingCollider:${definition.id}`,
+      });
+    }
+
+    if (definition.decorativeFootprint) {
+      furnishing.add(createDecorativePrimitive(lowerCompatibleDefinition));
+      decorativeFootprints.push({
+        id: `DecorativeFootprint:${definition.id}`,
+        furnishingId: definition.id,
+        category: definition.category,
+        roomId: definition.roomId,
+        bounds: createRotatedAabb(definition, definition.decorativeFootprint),
+        allowSolidOverlap:
+          definition.visual?.allowDecorativeOverlapWithSolid ||
+          definition.visual?.allowDecorativeOverlapWithAnySolid ||
+          false,
+      });
+    }
+
+    if (!definition.solidFootprint && !definition.decorativeFootprint) {
+      furnishing.add(createVisualDetailPrimitive(lowerCompatibleDefinition));
     }
 
     group.add(furnishing);
@@ -2183,7 +2358,14 @@ function createDecorativePrimitive(
 }
 
 function createRotatedAabb(
-  definition: LowerFloorFurnishingDefinition,
+  definition: {
+    position: { x: number; z: number };
+    orientationRadians: number;
+    solidFootprint?: LowerFloorFurnishingFootprint;
+    decorativeFootprint?: LowerFloorFurnishingFootprint;
+    solidBounds?: RectCollider;
+    decorativeBounds?: RectCollider;
+  },
   footprint: LowerFloorFurnishingFootprint
 ): RectCollider {
   if (definition.solidFootprint === footprint && definition.solidBounds) {

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -6,14 +6,19 @@ import {
   createBackyardFenceSegments,
 } from '../scene/level/backyardCollisionPolicies';
 import { isLevelSourceId } from '../scene/level/sourceIds';
+import { MANUAL_POI_PLACEMENTS } from '../scene/poi/placements';
 import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
+  UPPER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
   createLowerFloorFurnishings,
+  createUpperFloorFurnishings,
   rectanglesOverlap,
   validateLowerFloorFurnishingPlan,
+  validateUpperFloorFurnishingPlan,
   type LowerFloorFurnishingDefinition,
+  type UpperFloorFurnishingDefinition,
 } from '../scene/structures/lowerFloorFurnishings';
 import type { RectCollider } from '../systems/collision';
 
@@ -22,7 +27,7 @@ const validDefinitions: LowerFloorFurnishingDefinition[] = [
     id: 'living-couch-foundation',
     category: 'living-room-seating',
     roomId: 'livingRoom',
-    position: { x: -2, z: -21 },
+    position: { x: 22, z: -21 },
     orientationRadians: 0,
     solidFootprint: { width: 5.2, depth: 1.4 },
     kind: 'couch',
@@ -1179,7 +1184,7 @@ describe('lower floor furnishings foundation', () => {
         id: 'living-overlap-a',
         category: 'living-room-seating',
         roomId: 'livingRoom',
-        position: { x: -2, z: -21 },
+        position: { x: 22, z: -21 },
         orientationRadians: 0,
         solidFootprint: { width: 2, depth: 2 },
         kind: 'couch',
@@ -1189,7 +1194,7 @@ describe('lower floor furnishings foundation', () => {
         id: 'living-overlap-b',
         category: 'living-room-seating',
         roomId: 'livingRoom',
-        position: { x: -1.5, z: -21 },
+        position: { x: 22.5, z: -21 },
         orientationRadians: 0,
         solidFootprint: { width: 2, depth: 2 },
         kind: 'couch',
@@ -1264,6 +1269,159 @@ describe('lower floor furnishings foundation', () => {
         },
       ])
     ).toThrow(/empty decorative footprint/);
+  });
+
+  it('keeps the token.place manual placement in the living room away from sofa seating', () => {
+    const tokenPlace = MANUAL_POI_PLACEMENTS['tokenplace-studio-cluster'];
+    const sofaClusterBounds: RectCollider = {
+      minX: -29.2,
+      maxX: -21.2,
+      minZ: -23.8,
+      maxZ: -15.2,
+    };
+    const tokenPlaceReservedBlocker = LOWER_FLOOR_RESERVED_BLOCKERS.find(
+      (blocker) =>
+        blocker.minX === -0.6 &&
+        blocker.maxX === 4.2 &&
+        blocker.minZ === -23.2 &&
+        blocker.maxZ === -19.2
+    );
+
+    expect(tokenPlace).toMatchObject({
+      roomId: 'livingRoom',
+      position: { x: 1.8, z: -21.2 },
+    });
+    expect(tokenPlaceReservedBlocker).toBeDefined();
+    expect(
+      rectanglesOverlap(tokenPlaceReservedBlocker!, sofaClusterBounds)
+    ).toBe(false);
+  });
+
+  it('keeps the moved token.place reserved blocker clear of current lower solids', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const tokenPlaceReservedBlocker = LOWER_FLOOR_RESERVED_BLOCKERS.find(
+      (blocker) =>
+        blocker.minX === -0.6 &&
+        blocker.maxX === 4.2 &&
+        blocker.minZ === -23.2 &&
+        blocker.maxZ === -19.2
+    );
+
+    expect(tokenPlaceReservedBlocker).toBeDefined();
+    colliders.forEach((collider) => {
+      expect(rectanglesOverlap(tokenPlaceReservedBlocker!, collider)).toBe(
+        false
+      );
+    });
+  });
+});
+
+describe('upper floor furnishings foundation', () => {
+  const upperDefinitions: UpperFloorFurnishingDefinition[] = [
+    {
+      id: 'upper-landing-bench-foundation',
+      category: 'upper-landing',
+      roomId: 'upperLanding',
+      position: { x: 18, z: -22 },
+      orientationRadians: 0,
+      solidFootprint: { width: 2.4, depth: 1 },
+      kind: 'bench',
+    },
+    {
+      id: 'upper-library-rug-foundation',
+      category: 'loft-library',
+      roomId: 'loftLibrary',
+      position: { x: 14, z: -6 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 4, depth: 2 },
+      kind: 'rug',
+    },
+  ];
+
+  it('supports an empty default upper build routed to upper floor semantics', () => {
+    const build = createUpperFloorFurnishings();
+
+    expect(build.group.name).toBe('UpperFloorFurnishings');
+    expect(build.colliders).toEqual([]);
+    expect(build.decorativeFootprints).toEqual([]);
+  });
+
+  it('publishes the expected valid upper room bounds', () => {
+    expect(UPPER_FLOOR_ROOM_BOUNDS).toMatchObject({
+      upperLanding: { minX: 4, maxX: 20.8, minZ: -32, maxZ: -16 },
+      creatorsStudio: { minX: -20, maxX: 4, minZ: -32, maxZ: 0 },
+      loftLibrary: { minX: 4, maxX: 24, minZ: -16, maxZ: 12 },
+      focusPods: { minX: -20, maxX: 24, minZ: 12, maxZ: 28 },
+    });
+    Object.values(UPPER_FLOOR_ROOM_BOUNDS).forEach((bounds) => {
+      expect(bounds.maxX - bounds.minX).toBeGreaterThan(0);
+      expect(bounds.maxZ - bounds.minZ).toBeGreaterThan(0);
+    });
+  });
+
+  it('validates upper IDs, room containment, and non-overlapping solids', () => {
+    expect(() =>
+      validateUpperFloorFurnishingPlan(upperDefinitions)
+    ).not.toThrow();
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        { ...upperDefinitions[0], id: 'Invalid upper id' },
+      ])
+    ).toThrow(/not a valid furnishing ID/);
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        { ...upperDefinitions[0], position: { x: 30, z: -22 } },
+      ])
+    ).toThrow(/outside upperLanding/);
+    expect(() =>
+      validateUpperFloorFurnishingPlan([
+        upperDefinitions[0],
+        {
+          ...upperDefinitions[0],
+          id: 'upper-landing-overlap-foundation',
+          position: { x: 18.2, z: -22 },
+        },
+      ])
+    ).toThrow(/overlaps/);
+  });
+
+  it('emits unique upper source IDs and upper-floor collider metadata', () => {
+    const { colliders, group } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+    const sourceIds = colliders.map((collider) => collider.sourceId);
+
+    expect(colliders).toHaveLength(1);
+    expect(new Set(sourceIds).size).toBe(sourceIds.length);
+    expect(sourceIds.every((sourceId) => isLevelSourceId(sourceId))).toBe(true);
+    expect(colliders[0]).toMatchObject({
+      floorId: 'upper',
+      sourceType: 'generatedCollider',
+      purpose: 'upper-floor-furnishing',
+      sourceId:
+        'upper.furnishings.upper-landing.upper-landing-bench-foundation.generated_collider',
+      debugName: 'UpperFloorFurnishingCollider:upper-landing-bench-foundation',
+    });
+    expect(
+      group.getObjectByName('Furnishing:upper-landing-bench-foundation')
+    ).toBeDefined();
+  });
+
+  it('keeps upper decorative footprints non-blocking', () => {
+    const { colliders, decorativeFootprints } = createUpperFloorFurnishings({
+      definitions: upperDefinitions,
+    });
+
+    expect(
+      colliders.some((collider) => collider.furnishingId.includes('rug'))
+    ).toBe(false);
+    expect(decorativeFootprints).toHaveLength(1);
+    expect(decorativeFootprints[0]).toMatchObject({
+      furnishingId: 'upper-library-rug-foundation',
+      roomId: 'loftLibrary',
+      category: 'loft-library',
+      allowSolidOverlap: false,
+    });
   });
 });
 


### PR DESCRIPTION
### Motivation
- Prepare the furnishing system for an upstairs density pass with the same authoring/validation rigor as the ground floor. 
- Move the `tokenplace-studio-cluster` POI out of the sofa/media seating cluster while keeping it in the same room to avoid collisions.
- Keep the existing lower-floor API and validation behavior intact so prior furnishing waves remain unchanged.

### Description
- Add upper-floor authoring types, room bounds, reserved blockers, shared validation helper `validateFurnishingPlan`, and `createUpperFloorFurnishings()` with generated-collider metadata in `src/scene/structures/lowerFloorFurnishings.ts`.
- Wire upper-floor visuals and colliders into runtime visibility and collider registration by calling `createUpperFloorFurnishings()` and adding results to `upperStructureGroup` / `upperFloorColliders` in `src/main.ts`.
- Reflow `tokenplace-studio-cluster` placement to living-room position `{ x: 1.8, z: -21.2 }` with heading `-Math.PI * 0.18` and update its interaction anchor in `src/scene/poi/placements.ts` and tests.
- Update reserved-blocker constants so the new token.place area is represented and does not overlap the sofa cluster, plus update miniature manifest and POI proxy `syncRevision`/notes to acknowledge source changes.
- Tests: extend `src/tests/lowerFloorFurnishings.test.ts` to cover token.place placement and new upper-floor validation/build expectations and update `src/scene/poi/placements.test.ts`.

### Testing
- Ran `npm run format:write` and `npm run lint` — formatting applied and linter finished with no blocking errors.
- Ran `npm run typecheck` — failed due to pre-existing, repository-wide TypeScript issues unrelated to these changes (reported and left unchanged).
- Ran focused tests: `npm run test:ci -- lowerFloorFurnishings miniatureManifest placements` — passed after updating the miniature manifest and proxy sync revisions.
- Ran full test suite `npm run test:ci` — initial full run flagged a stale miniature manifest which was then updated; subsequent runs passed the focused suites and the manifest checks (full CI had unrelated warnings but no blocking failures after the manifest update).
- Built production bundle with `npm run build` — succeeded.
- Docs and smoke checks: `npm run docs:check` and `npm run smoke` — passed (link-check showed external unreachable link warnings, which are informational).
- Secret scan: `git diff --cached | ./scripts/scan-secrets.py` — no high-risk secrets detected.

Notes and residual risk: `tsc` reports pre-existing type errors across the repo; this PR avoids changing those areas beyond the scoped furnishing work, but maintainers may want to address global typecheck noise separately. The miniature manifest required a deliberate `syncRevision`/`syncNote` and some POI proxy `syncRevision` bumps to acknowledge source updates; that bookkeeping is included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42a5f0d06c832f939aaad102fdd5f6)