### PR TITLE
🌿 Add dense downstairs decor pass

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 22,
-      "syncNote": "Token.place blocker follows the northwest living-room reflow; furniture proxy coverage remains deferred.",
-      "sourceFingerprint": "a3f165013a9d62ae42a1c307a24868039651b54c2b1d17456779a0472773f5d1",
+      "syncRevision": 23,
+      "syncNote": "Dense downstairs decor adds source-only plants, rugs, and details while proxy coverage remains deferred.",
+      "sourceFingerprint": "36431b37831fc4a488610e8fe855f71d497d1df6cb56d7d5e722d7f6971b526e",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "bfacc20cac438c1571348ff2cfa544952e5c09c30c81a52c28b12f96f182683b"
+      "metadataFingerprint": "10ec763e12fcd7488a60d58962664e652bfaf532b71e0497a83bef2fc4794f03"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 22,
+    syncRevision: 23,
     syncNote:
-      'Token.place blocker follows the northwest living-room reflow; furniture proxy coverage remains deferred.',
+      'Dense downstairs decor adds source-only plants, rugs, and details while proxy coverage remains deferred.',
     reason:
       'Plants and warm decor remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -314,6 +314,104 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
     },
 
     {
+      id: 'living-room-tv-pothos-left',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -29.8, z: -24.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -30.15, maxX: -29.45, minZ: -25.15, maxZ: -24.45 },
+      kind: 'plant-stool',
+      visual: { color: 0x6a4a32, accentColor: 0x4f9a55, height: 1.05 },
+    },
+    {
+      id: 'living-room-corner-fig',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: 30.2, z: -29.5 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.0, depth: 1.0 },
+      solidBounds: { minX: 29.7, maxX: 30.7, minZ: -30.0, maxZ: -29.0 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x7a5134, accentColor: 0x4f8f4f, height: 1.85 },
+    },
+    {
+      id: 'living-room-reading-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -23.1, z: -12.7 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.65, depth: 0.65 },
+      solidBounds: {
+        minX: -23.425,
+        maxX: -22.775,
+        minZ: -13.025,
+        maxZ: -12.375,
+      },
+      kind: 'monstera-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x6e9b58, height: 1.05 },
+    },
+    {
+      id: 'living-room-floor-cushion-west',
+      category: 'living-room-seating',
+      roomId: 'livingRoom',
+      position: { x: -20.4, z: -15.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      solidBounds: { minX: -20.85, maxX: -19.95, minZ: -15.85, maxZ: -14.95 },
+      kind: 'floor-cushion',
+      visual: { color: 0xb86f5f, accentColor: 0xd8c7a7, height: 0.28 },
+    },
+    {
+      id: 'living-room-round-pouf',
+      category: 'living-room-seating',
+      roomId: 'livingRoom',
+      position: { x: -18.4, z: -17.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      solidBounds: { minX: -18.85, maxX: -17.95, minZ: -17.45, maxZ: -16.55 },
+      kind: 'round-pouf',
+      visual: { color: 0x7d6f89, accentColor: 0xd8c7a7, height: 0.42 },
+    },
+    {
+      id: 'living-room-slim-entry-console',
+      category: 'storage',
+      roomId: 'livingRoom',
+      position: { x: 3.2, z: -13.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 2.6, depth: 0.7 },
+      solidBounds: { minX: 1.9, maxX: 4.5, minZ: -13.35, maxZ: -12.65 },
+      kind: 'storage-drawer-console',
+      visual: { color: 0x4b5563, accentColor: 0xc4955a, height: 0.78 },
+    },
+    {
+      id: 'living-room-wall-art-south-triptych',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: 14.0, z: -31.85 },
+      orientationRadians: 0,
+      kind: 'wall-art-triptych-detail',
+      visual: { color: 0xd6c3a3, accentColor: 0x384c5c, height: 1.35 },
+    },
+    {
+      id: 'living-room-console-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'livingRoom',
+      position: { x: -2.0, z: -31.1 },
+      orientationRadians: 0,
+      kind: 'console-plant-detail',
+      visual: { color: 0xb7834f, accentColor: 0x6f9f5d, height: 1.0 },
+    },
+    {
+      id: 'living-room-coffee-table-bowl',
+      category: 'living-room-seating',
+      roomId: 'livingRoom',
+      position: { x: -22.5, z: -18.4 },
+      orientationRadians: 0,
+      kind: 'table-bowl-detail',
+      visual: { color: 0xcaa66a, accentColor: 0x8fd0a6, height: 0.5 },
+    },
+    {
       id: 'kitchen-west-counter-run',
       category: 'kitchenette',
       roomId: 'kitchen',
@@ -413,6 +511,95 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
     },
 
     {
+      id: 'kitchen-breakfast-table',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -7.1, z: -5.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.6, depth: 1.2 },
+      solidBounds: { minX: -7.9, maxX: -6.3, minZ: -6.4, maxZ: -5.2 },
+      kind: 'kitchen-breakfast-table',
+      visual: { color: 0x6b4a33, accentColor: 0xd0bea2, height: 0.72 },
+    },
+    {
+      id: 'kitchen-breakfast-stool-a',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -9.0, z: -5.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.6, depth: 0.6 },
+      solidBounds: { minX: -9.3, maxX: -8.7, minZ: -6.1, maxZ: -5.5 },
+      kind: 'kitchen-bar-stool',
+      visual: { color: 0x2f3740, accentColor: 0xc28d52, height: 0.72 },
+    },
+    {
+      id: 'kitchen-breakfast-stool-b',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -5.5, z: -5.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.6, depth: 0.6 },
+      solidBounds: { minX: -5.8, maxX: -5.2, minZ: -6.1, maxZ: -5.5 },
+      kind: 'kitchen-bar-stool',
+      visual: { color: 0x2f3740, accentColor: 0xc28d52, height: 0.72 },
+    },
+    {
+      id: 'kitchen-round-plant-stand',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -7.0, z: 13.5 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: -7.35, maxX: -6.65, minZ: 13.15, maxZ: 13.85 },
+      kind: 'plant-stool',
+      visual: { color: 0x6a4a32, accentColor: 0x6f9f5d, height: 0.95 },
+    },
+    {
+      id: 'kitchen-tall-pantry-south',
+      category: 'storage',
+      roomId: 'kitchen',
+      position: { x: -29.2, z: -6.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.1, depth: 1.4 },
+      solidBounds: { minX: -29.75, maxX: -28.65, minZ: -7.6, maxZ: -6.2 },
+      kind: 'storage-tall-bookcase',
+      visual: { color: 0x56616f, accentColor: 0xd8ccb8, height: 2.2 },
+    },
+    {
+      id: 'kitchen-runner-rug',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -21.0, z: 9.3 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 5.5, depth: 1.6 },
+      decorativeBounds: { minX: -23.75, maxX: -18.25, minZ: 8.5, maxZ: 10.1 },
+      kind: 'kitchen-runner-rug',
+      visual: {
+        color: 0x8a5f54,
+        accentColor: 0xd6c3a3,
+        decorativeHeight: 0.025,
+      },
+    },
+    {
+      id: 'kitchen-wall-spice-rack',
+      category: 'kitchenette',
+      roomId: 'kitchen',
+      position: { x: -31.2, z: 1.8 },
+      orientationRadians: 0,
+      kind: 'spice-rack-detail',
+      visual: { color: 0x6b4a33, accentColor: 0xcaa66a, height: 1.35 },
+    },
+    {
+      id: 'kitchen-counter-herb-cluster',
+      category: 'plants-lighting-decor',
+      roomId: 'kitchen',
+      position: { x: -13.0, z: 10.9 },
+      orientationRadians: 0,
+      kind: 'herb-planter-detail',
+      visual: { color: 0xb7834f, accentColor: 0x6f9f5d, height: 1.0 },
+    },
+
+    {
       id: 'living-room-south-bookcase-west',
       category: 'storage',
       roomId: 'livingRoom',
@@ -503,6 +690,29 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
     },
 
     {
+      id: 'studio-paper-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 21.0, z: 8.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      solidBounds: { minX: 20.725, maxX: 21.275, minZ: 7.725, maxZ: 8.275 },
+      kind: 'floor-lamp',
+      visual: { color: 0xd6c3a3, accentColor: 0xffd48a, height: 1.65 },
+    },
+    {
+      id: 'studio-narrow-plant-east',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 30.5, z: 7.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      solidBounds: { minX: 30.15, maxX: 30.85, minZ: 7.05, maxZ: 7.75 },
+      kind: 'monstera-plant',
+      visual: { color: 0x7a5134, accentColor: 0x4f8f4f, height: 1.45 },
+    },
+
+    {
       id: 'studio-daybed',
       category: 'sleeping-nook',
       roomId: 'studio',
@@ -562,6 +772,55 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
         allowDecorativeOverlapWithAnySolid: true,
       },
     },
+
+    {
+      id: 'studio-round-side-table',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 21.2, z: 10.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 20.8, maxX: 21.6, minZ: 9.6, maxZ: 10.4 },
+      kind: 'side-table',
+      visual: { color: 0x75513a, accentColor: 0x221d1a, height: 0.55 },
+    },
+    {
+      id: 'studio-low-storage-bench',
+      category: 'storage',
+      roomId: 'studio',
+      position: { x: 6.0, z: -6.9 },
+      orientationRadians: 0,
+      solidFootprint: { width: 3.2, depth: 0.8 },
+      solidBounds: { minX: 4.4, maxX: 7.6, minZ: -7.3, maxZ: -6.5 },
+      kind: 'storage-drawer-console',
+      visual: { color: 0x56616f, accentColor: 0xd8ccb8, height: 0.56 },
+    },
+    {
+      id: 'studio-woven-rug',
+      category: 'sleeping-nook',
+      roomId: 'studio',
+      position: { x: 24.4, z: 8.8 },
+      orientationRadians: 0,
+      decorativeFootprint: { width: 5.4, depth: 3.6 },
+      decorativeBounds: { minX: 21.7, maxX: 27.1, minZ: 7.0, maxZ: 10.6 },
+      kind: 'studio-woven-rug',
+      visual: {
+        color: 0x6d5f4b,
+        accentColor: 0xd6c3a3,
+        decorativeHeight: 0.025,
+        allowDecorativeOverlapWithAnySolid: true,
+      },
+    },
+    {
+      id: 'studio-hanging-plant-east',
+      category: 'plants-lighting-decor',
+      roomId: 'studio',
+      position: { x: 31.8, z: 9.2 },
+      orientationRadians: 0,
+      kind: 'hanging-plant-detail',
+      visual: { color: 0xb7834f, accentColor: 0x6f9f5d, height: 1.75 },
+    },
+
     {
       id: 'living-room-media-rug',
       category: 'living-room-seating',
@@ -683,6 +942,81 @@ export const DEFAULT_LOWER_FLOOR_FURNISHINGS: readonly LowerFloorFurnishingDefin
       kind: 'backyard-rock',
       visual: { color: 0x807b72, accentColor: 0xaaa397, height: 0.36 },
     },
+
+    {
+      id: 'backyard-birdbath',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 8.5, z: 20.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.1, depth: 1.1 },
+      solidBounds: { minX: 7.95, maxX: 9.05, minZ: 19.45, maxZ: 20.55 },
+      kind: 'backyard-birdbath',
+      visual: { color: 0x9aa8b7, accentColor: 0x8ecae6, height: 0.95 },
+    },
+    {
+      id: 'backyard-herb-trough-north',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -5.5, z: 30.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 3.0, depth: 0.6 },
+      solidBounds: { minX: -7.0, maxX: -4.0, minZ: 30.5, maxZ: 31.1 },
+      kind: 'backyard-herb-trough',
+      visual: { color: 0x7a5134, accentColor: 0x6f9f5d, height: 0.65 },
+    },
+    {
+      id: 'backyard-flower-cluster-sw',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -28.0, z: 18.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      solidBounds: { minX: -28.45, maxX: -27.55, minZ: 17.75, maxZ: 18.65 },
+      kind: 'backyard-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0xd66f8d, height: 1.0 },
+    },
+    {
+      id: 'backyard-patio-umbrella-base',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -22.0, z: 25.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      solidBounds: { minX: -22.45, maxX: -21.55, minZ: 24.55, maxZ: 25.45 },
+      kind: 'backyard-umbrella-base',
+      visual: { color: 0x2f3740, accentColor: 0xd6c3a3, height: 2.4 },
+    },
+    {
+      id: 'backyard-garden-stool',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 21.2, z: 28.5 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      solidBounds: { minX: 20.8, maxX: 21.6, minZ: 28.1, maxZ: 28.9 },
+      kind: 'backyard-garden-stool',
+      visual: { color: 0x78966f, accentColor: 0xd8c7a7, height: 0.55 },
+    },
+    {
+      id: 'backyard-string-lights',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: 24.0, z: 21.0 },
+      orientationRadians: 0,
+      kind: 'string-lights-detail',
+      visual: { color: 0x2f3740, accentColor: 0xffd48a, height: 2.55 },
+    },
+    {
+      id: 'backyard-watering-can',
+      category: 'backyard',
+      roomId: 'backyard',
+      position: { x: -6.6, z: 30.7 },
+      orientationRadians: 0,
+      kind: 'watering-can-detail',
+      visual: { color: 0x6f8aa0, accentColor: 0xc9d1d6, height: 0.35 },
+    },
+
     {
       id: 'backyard-planter-west-south',
       category: 'backyard',
@@ -2079,6 +2413,94 @@ function createBackyardFurnishing(
     return group;
   }
 
+  if (definition.kind === 'backyard-birdbath') {
+    addBox(
+      group,
+      'birdbathPedestal',
+      { width: 0.24, height: 0.62, depth: 0.24 },
+      primaryMaterial,
+      [0, 0.31, 0]
+    );
+    addBox(
+      group,
+      'birdbathBasin',
+      { width: 0.82, height: 0.16, depth: 0.82 },
+      primaryMaterial,
+      [0, 0.7, 0]
+    );
+    addBox(
+      group,
+      'birdbathWater',
+      { width: 0.62, height: 0.035, depth: 0.62 },
+      accentMaterial,
+      [0, 0.8, 0]
+    );
+    return group;
+  }
+
+  if (definition.kind === 'backyard-herb-trough') {
+    addBox(
+      group,
+      'herbTroughBox',
+      { width: footprint.width, height: 0.32, depth: footprint.depth },
+      primaryMaterial,
+      [0, 0.16, 0]
+    );
+    [-1.0, -0.5, 0, 0.5, 1.0].forEach((x, index) => {
+      addBox(
+        group,
+        `herbTroughSprout${index}`,
+        { width: 0.16, height: 0.34, depth: 0.16 },
+        accentMaterial,
+        [x, 0.48, 0]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'backyard-umbrella-base') {
+    addBox(
+      group,
+      'umbrellaBase',
+      { width: 0.72, height: 0.16, depth: 0.72 },
+      primaryMaterial,
+      [0, 0.08, 0]
+    );
+    addBox(
+      group,
+      'umbrellaPole',
+      { width: 0.08, height, depth: 0.08 },
+      darkMaterial,
+      [0, height / 2, 0]
+    );
+    addBox(
+      group,
+      'umbrellaCanopy',
+      { width: 1.8, height: 0.12, depth: 1.8 },
+      accentMaterial,
+      [0, height, 0]
+    );
+    return group;
+  }
+
+  if (definition.kind === 'backyard-garden-stool') {
+    addBox(
+      group,
+      'gardenStoolSeat',
+      { width: 0.62, height: 0.16, depth: 0.62 },
+      primaryMaterial,
+      [0, height, 0]
+    );
+    addBox(
+      group,
+      'gardenStoolCore',
+      { width: 0.42, height, depth: 0.42 },
+      accentMaterial,
+      [0, height / 2, 0]
+    );
+    return group;
+  }
+
   throw new Error(`Unsupported backyard furnishing kind: ${definition.kind}`);
 }
 
@@ -2278,6 +2700,127 @@ function createVisualDetailPrimitive(
         [x, 1.58, 0]
       );
     });
+    return group;
+  }
+
+  if (definition.kind === 'wall-art-triptych-detail') {
+    [-0.72, 0, 0.72].forEach((x, index) => {
+      addBox(
+        group,
+        `wallArtPanel${index}`,
+        { width: 0.5, height: 0.7, depth: 0.04 },
+        accentMaterial,
+        [x, 1.35, 0]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'console-plant-detail') {
+    addTinyPlant(group, 'consolePlant', 0, 0.92, 0);
+    return group;
+  }
+
+  if (definition.kind === 'table-bowl-detail') {
+    addBox(
+      group,
+      'coffeeTableBowl',
+      { width: 0.38, height: 0.12, depth: 0.28 },
+      baseMaterial,
+      [0, 0.55, 0]
+    );
+    addBox(
+      group,
+      'coffeeTableBowlFruit',
+      { width: 0.12, height: 0.1, depth: 0.12 },
+      accentMaterial,
+      [0.08, 0.66, 0]
+    );
+    return group;
+  }
+
+  if (definition.kind === 'spice-rack-detail') {
+    addBox(
+      group,
+      'spiceRackShelf',
+      { width: 0.08, height: 0.12, depth: 1.15 },
+      baseMaterial,
+      [0, 1.35, 0]
+    );
+    [-0.36, 0, 0.36].forEach((z, index) => {
+      addBox(
+        group,
+        `spiceJar${index}`,
+        { width: 0.12, height: 0.28, depth: 0.12 },
+        accentMaterial,
+        [0, 1.55, z]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'hanging-plant-detail') {
+    addBox(
+      group,
+      'hangingPlantCord',
+      { width: 0.035, height: 0.72, depth: 0.035 },
+      baseMaterial,
+      [0, 1.65, 0]
+    );
+    addBox(
+      group,
+      'hangingPlantPot',
+      { width: 0.34, height: 0.24, depth: 0.34 },
+      baseMaterial,
+      [0, 1.18, 0]
+    );
+    [-0.14, 0, 0.14].forEach((x, index) => {
+      addBox(
+        group,
+        `hangingPlantTrail${index}`,
+        { width: 0.08, height: 0.42, depth: 0.08 },
+        accentMaterial,
+        [x, 0.9, 0]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'string-lights-detail') {
+    addBox(
+      group,
+      'stringLightCable',
+      { width: 5.2, height: 0.035, depth: 0.035 },
+      baseMaterial,
+      [0, 2.55, 0]
+    );
+    [-2, -1, 0, 1, 2].forEach((x, index) => {
+      addBox(
+        group,
+        `stringLightBulb${index}`,
+        { width: 0.12, height: 0.16, depth: 0.12 },
+        accentMaterial,
+        [x, 2.42, 0]
+      );
+    });
+    return group;
+  }
+
+  if (definition.kind === 'watering-can-detail') {
+    addBox(
+      group,
+      'wateringCanBody',
+      { width: 0.34, height: 0.22, depth: 0.24 },
+      baseMaterial,
+      [0, 0.28, 0]
+    );
+    addBox(
+      group,
+      'wateringCanSpout',
+      { width: 0.34, height: 0.06, depth: 0.06 },
+      accentMaterial,
+      [0.28, 0.34, 0]
+    );
     return group;
   }
 

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -87,8 +87,8 @@ describe('lower floor furnishings foundation', () => {
     const build = createLowerFloorFurnishings();
 
     expect(build.group.name).toBe('LowerFloorFurnishings');
-    expect(build.colliders).toHaveLength(39);
-    expect(build.decorativeFootprints).toHaveLength(3);
+    expect(build.colliders).toHaveLength(59);
+    expect(build.decorativeFootprints).toHaveLength(5);
     expect(DEFAULT_LOWER_FLOOR_FURNISHINGS.map(({ id }) => id)).toEqual([
       'living-room-media-sofa',
       'living-room-coffee-table',
@@ -100,6 +100,15 @@ describe('lower floor furnishings foundation', () => {
       'living-room-plant-stool',
       'kitchen-herb-planter',
       'kitchen-pendant-lights',
+      'living-room-tv-pothos-left',
+      'living-room-corner-fig',
+      'living-room-reading-plant',
+      'living-room-floor-cushion-west',
+      'living-room-round-pouf',
+      'living-room-slim-entry-console',
+      'living-room-wall-art-south-triptych',
+      'living-room-console-plant',
+      'living-room-coffee-table-bowl',
       'kitchen-west-counter-run',
       'kitchen-fridge',
       'kitchen-sink-cabinet',
@@ -108,6 +117,14 @@ describe('lower floor furnishings foundation', () => {
       'kitchen-bar-stool-west',
       'kitchen-bar-stool-east',
       'kitchen-trash-drawer',
+      'kitchen-breakfast-table',
+      'kitchen-breakfast-stool-a',
+      'kitchen-breakfast-stool-b',
+      'kitchen-round-plant-stand',
+      'kitchen-tall-pantry-south',
+      'kitchen-runner-rug',
+      'kitchen-wall-spice-rack',
+      'kitchen-counter-herb-cluster',
       'living-room-south-bookcase-west',
       'living-room-south-open-shelf',
       'living-room-drawer-console',
@@ -116,11 +133,17 @@ describe('lower floor furnishings foundation', () => {
       'studio-east-dresser',
       'studio-floor-lamp',
       'studio-monstera',
+      'studio-paper-lamp',
+      'studio-narrow-plant-east',
       'studio-daybed',
       'studio-nightstand-south',
       'studio-nightstand-north',
       'studio-reading-chair',
       'studio-bedside-rug',
+      'studio-round-side-table',
+      'studio-low-storage-bench',
+      'studio-woven-rug',
+      'studio-hanging-plant-east',
       'living-room-media-rug',
       'backyard-lawn-chair-west-a',
       'backyard-lawn-chair-west-b',
@@ -131,6 +154,13 @@ describe('lower floor furnishings foundation', () => {
       'backyard-rock-01',
       'backyard-rock-02',
       'backyard-rock-03',
+      'backyard-birdbath',
+      'backyard-herb-trough-north',
+      'backyard-flower-cluster-sw',
+      'backyard-patio-umbrella-base',
+      'backyard-garden-stool',
+      'backyard-string-lights',
+      'backyard-watering-can',
       'backyard-planter-west-south',
       'backyard-planter-west-north',
       'backyard-planter-east-south',
@@ -911,8 +941,7 @@ describe('lower floor furnishings foundation', () => {
     );
 
     kitchenDefinitions.forEach((definition) => {
-      if (definition.id === 'kitchen-stove-cabinet') {
-        expect(definition.solidFootprint).toBeUndefined();
+      if (!definition.solidFootprint) {
         expect(definition.solidBounds).toBeUndefined();
         return;
       }
@@ -1471,6 +1500,173 @@ describe('upper floor furnishings foundation', () => {
           blocker.maxZ > -32
       )
     ).toBe(false);
+  });
+
+  it('adds dense downstairs decor pass solids and non-blocking details', () => {
+    const { colliders, decorativeFootprints, group } =
+      createLowerFloorFurnishings();
+    const expectedSolidBounds: Record<string, RectCollider> = {
+      'living-room-tv-pothos-left': {
+        minX: -30.15,
+        maxX: -29.45,
+        minZ: -25.15,
+        maxZ: -24.45,
+      },
+      'living-room-corner-fig': {
+        minX: 29.7,
+        maxX: 30.7,
+        minZ: -30,
+        maxZ: -29,
+      },
+      'living-room-reading-plant': {
+        minX: -23.425,
+        maxX: -22.775,
+        minZ: -13.025,
+        maxZ: -12.375,
+      },
+      'living-room-floor-cushion-west': {
+        minX: -20.85,
+        maxX: -19.95,
+        minZ: -15.85,
+        maxZ: -14.95,
+      },
+      'living-room-round-pouf': {
+        minX: -18.85,
+        maxX: -17.95,
+        minZ: -17.45,
+        maxZ: -16.55,
+      },
+      'living-room-slim-entry-console': {
+        minX: 1.9,
+        maxX: 4.5,
+        minZ: -13.35,
+        maxZ: -12.65,
+      },
+      'kitchen-breakfast-table': {
+        minX: -7.9,
+        maxX: -6.3,
+        minZ: -6.4,
+        maxZ: -5.2,
+      },
+      'kitchen-breakfast-stool-a': {
+        minX: -9.3,
+        maxX: -8.7,
+        minZ: -6.1,
+        maxZ: -5.5,
+      },
+      'kitchen-breakfast-stool-b': {
+        minX: -5.8,
+        maxX: -5.2,
+        minZ: -6.1,
+        maxZ: -5.5,
+      },
+      'kitchen-round-plant-stand': {
+        minX: -7.35,
+        maxX: -6.65,
+        minZ: 13.15,
+        maxZ: 13.85,
+      },
+      'kitchen-tall-pantry-south': {
+        minX: -29.75,
+        maxX: -28.65,
+        minZ: -7.6,
+        maxZ: -6.2,
+      },
+      'studio-paper-lamp': {
+        minX: 20.725,
+        maxX: 21.275,
+        minZ: 7.725,
+        maxZ: 8.275,
+      },
+      'studio-narrow-plant-east': {
+        minX: 30.15,
+        maxX: 30.85,
+        minZ: 7.05,
+        maxZ: 7.75,
+      },
+      'studio-round-side-table': {
+        minX: 20.8,
+        maxX: 21.6,
+        minZ: 9.6,
+        maxZ: 10.4,
+      },
+      'studio-low-storage-bench': {
+        minX: 4.4,
+        maxX: 7.6,
+        minZ: -7.3,
+        maxZ: -6.5,
+      },
+      'backyard-birdbath': { minX: 7.95, maxX: 9.05, minZ: 19.45, maxZ: 20.55 },
+      'backyard-herb-trough-north': {
+        minX: -7,
+        maxX: -4,
+        minZ: 30.5,
+        maxZ: 31.1,
+      },
+      'backyard-flower-cluster-sw': {
+        minX: -28.45,
+        maxX: -27.55,
+        minZ: 17.75,
+        maxZ: 18.65,
+      },
+      'backyard-patio-umbrella-base': {
+        minX: -22.45,
+        maxX: -21.55,
+        minZ: 24.55,
+        maxZ: 25.45,
+      },
+      'backyard-garden-stool': {
+        minX: 20.8,
+        maxX: 21.6,
+        minZ: 28.1,
+        maxZ: 28.9,
+      },
+    };
+
+    Object.entries(expectedSolidBounds).forEach(([id, bounds]) => {
+      expect(
+        colliders.filter((collider) => collider.furnishingId === id)
+      ).toHaveLength(1);
+      expect(
+        colliders.find((collider) => collider.furnishingId === id)
+      ).toMatchObject(bounds);
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+    });
+
+    ['kitchen-runner-rug', 'studio-woven-rug'].forEach((id) => {
+      expect(
+        decorativeFootprints.some((footprint) => footprint.furnishingId === id)
+      ).toBe(true);
+      expect(colliders.some((collider) => collider.furnishingId === id)).toBe(
+        false
+      );
+    });
+
+    [
+      'living-room-wall-art-south-triptych',
+      'living-room-console-plant',
+      'living-room-coffee-table-bowl',
+      'kitchen-wall-spice-rack',
+      'kitchen-counter-herb-cluster',
+      'studio-hanging-plant-east',
+      'backyard-string-lights',
+      'backyard-watering-can',
+    ].forEach((id) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+      expect(colliders.some((collider) => collider.furnishingId === id)).toBe(
+        false
+      );
+    });
+
+    const plantDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      ({ id, kind }) =>
+        kind.includes('plant') ||
+        kind.includes('herb') ||
+        id.includes('pothos') ||
+        id.includes('fig') ||
+        id.includes('flower')
+    );
+    expect(plantDefinitions.length).toBeGreaterThanOrEqual(10);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Increase perceived downstairs decor density with tasteful, camera-friendly plants, small furniture, rugs, and visual-only tabletop/wall details while preserving POI, door, and navigation clearances.
- Emphasize varied greenery (pothos, fiddle‑leaf fig, monstera/ZZ/snake, herb troughs, hanging plants) and add non-blocking rugs/tabletop accents to make spaces feel lived-in without adding navigation blockers.

### Description
- Added ~30 new lower-floor furnishing definitions to `DEFAULT_LOWER_FLOOR_FURNISHINGS` (living room, kitchen, studio, backyard) including solids (e.g., `living-room-tv-pothos-left`, `living-room-corner-fig`, `kitchen-breakfast-table`, `studio-paper-lamp`, `backyard-birdbath`, `backyard-herb-trough-north`) and decorative-only items (rugs, wall art, hanging plants, spice rack, string lights, watering can).
- Implemented low-poly visual primitives for the new kinds in `createBackyardFurnishing` and `createVisualDetailPrimitive` (birdbath, herb trough, umbrella base, garden stool, wall‑art triptych, console/tabletop details, hanging plants, string lights, watering can) so visuals are deterministic and non-blocking where required.
- Updated furnishing-kind handling for kitchen/studio/backyard/detail kinds so new entries render correctly and maintain authored AABBs and categories.
- Updated miniature metadata by bumping `decor:lower-floor-furnishings` `syncRevision` and `syncNote` and regenerated `miniatureManifest.generated.json` to acknowledge source-only proxy state.
- Extended tests in `src/tests/lowerFloorFurnishings.test.ts` to assert presence and AABBs of all new P10 solid IDs, verify at least 10 plant visuals, and confirm non-blocking decorative footprints for rugs/details.

### Testing
- Ran `npm run format:write` and formatting was applied successfully.
- Ran `npm run test:ci -- lowerFloorFurnishings` and the focused furnishing suite passed (updated expectations for added colliders and decorative footprints).
- Ran `npm run test:ci -- miniatureManifest` after updating `syncRevision` and the miniature manifest check passed; `npm run miniature:manifest:update` was used to update the generated manifest file.
- Ran full `npm run test:ci` and the repository test suite completed with all tests passing after the manifest update (full suite run: 182 files, 1446 tests passed in this environment); link checker emitted non-fatal external fetch warnings.
- Ran `npm run build`, `npm run lint`, `npm run docs:check`, and `npm run smoke` and they completed (docs check/link warnings are informational; smoke/build succeeded), and secrets scan returned no high-risk findings.
- Ran `npm run typecheck` and observed pre-existing repository-wide TypeScript issues unrelated to these changes; these are not introduced by this PR and require separate investigation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a442589b6fc832f9fd7bafc6c53895c)