### PR TITLE
Add upstairs decor density: plants, lamps, art, rugs, and small details

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 28,
-      "syncNote": "Multi-floor furniture remains source-only while shelf detail proxy coverage is deferred.",
-      "sourceFingerprint": "41777c5cae694afbfa3c312b3b1317948561b0bcde79a97b84a483b714008ce2",
+      "syncRevision": 29,
+      "syncNote": "Upstairs decor density remains source-only until the furnishing proxy pass.",
+      "sourceFingerprint": "ea65684cecb2231f507bc8d28d3ff592d4fb2640921fb7ebcb8aad8b65b97071",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "6b074bb8aca259c122ee35cb861be6b5fc9506a4e875effa0070f964b52a6f41"
+      "metadataFingerprint": "a85f75d15d1f5789824f8726273b36f579c1c448d3e64dfaec53c01e1c280e29"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 28,
+    syncRevision: 29,
     syncNote:
-      'Multi-floor furniture remains source-only while shelf detail proxy coverage is deferred.',
+      'Upstairs decor density remains source-only until the furnishing proxy pass.',
     reason:
       'Lower- and upper-floor furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -378,6 +378,215 @@ export const DEFAULT_UPPER_FLOOR_FURNISHINGS: readonly UpperFloorFurnishingDefin
       visual: { color: 0x46536a, accentColor: 0xd8ccb8, height: 1.45 },
     },
     {
+      id: 'upper-landing-snake-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'upperLanding',
+      position: { x: 5.0, z: -17.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      kind: 'snake-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x4f8f4f, height: 1.45 },
+    },
+    {
+      id: 'upper-landing-gallery-plinth',
+      category: 'plants-lighting-decor',
+      roomId: 'upperLanding',
+      position: { x: 15.8, z: -30.4 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      kind: 'gallery-plinth',
+      visual: { color: 0xd8ccb8, accentColor: 0x56616f, height: 0.9 },
+    },
+    {
+      id: 'creators-studio-fern-stand',
+      category: 'plants-lighting-decor',
+      roomId: 'creatorsStudio',
+      position: { x: 0.8, z: -13.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      kind: 'fern-plant',
+      visual: { color: 0x6a4a32, accentColor: 0x5f9f63, height: 1.05 },
+    },
+    {
+      id: 'creators-studio-floor-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'creatorsStudio',
+      position: { x: -1.0, z: -25.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      kind: 'floor-lamp',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.55 },
+    },
+    {
+      id: 'creators-studio-tool-cart',
+      category: 'creators-studio',
+      roomId: 'creatorsStudio',
+      position: { x: -8.0, z: -3.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.2, depth: 0.8 },
+      kind: 'storage-open-shelf',
+      visual: { color: 0x56616f, accentColor: 0xc29249, height: 0.82 },
+    },
+    {
+      id: 'loft-library-window-planter',
+      category: 'plants-lighting-decor',
+      roomId: 'loftLibrary',
+      position: { x: 5.0, z: 10.2 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.8, depth: 0.8 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x8a5a36, accentColor: 0x6e9b58, height: 0.95 },
+    },
+    {
+      id: 'loft-library-east-snake-plant',
+      category: 'plants-lighting-decor',
+      roomId: 'loftLibrary',
+      position: { x: 23.0, z: -12.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.7, depth: 0.7 },
+      kind: 'snake-plant',
+      visual: { color: 0x7a5134, accentColor: 0x5f8f48, height: 1.45 },
+    },
+    {
+      id: 'loft-library-ottoman',
+      category: 'loft-library',
+      roomId: 'loftLibrary',
+      position: { x: 11.0, z: -11.6 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      kind: 'round-pouf',
+      visual: { color: 0x7d6f89, accentColor: 0xd8c7a7, height: 0.38 },
+    },
+    {
+      id: 'focus-pods-tree-planter',
+      category: 'plants-lighting-decor',
+      roomId: 'focusPods',
+      position: { x: 22.7, z: 26.8 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.9, depth: 0.9 },
+      kind: 'large-potted-plant',
+      visual: { color: 0x7a5134, accentColor: 0x4f8f4f, height: 1.85 },
+    },
+    {
+      id: 'focus-pods-low-plant-row-west',
+      category: 'plants-lighting-decor',
+      roomId: 'focusPods',
+      position: { x: -18.0, z: 25.0 },
+      orientationRadians: 0,
+      solidFootprint: { width: 1.2, depth: 0.7 },
+      kind: 'herb-trough',
+      visual: { color: 0x8a5a36, accentColor: 0x6f9f5d, height: 0.65 },
+    },
+    {
+      id: 'focus-pods-floor-lamp',
+      category: 'plants-lighting-decor',
+      roomId: 'focusPods',
+      position: { x: 8.0, z: 26.3 },
+      orientationRadians: 0,
+      solidFootprint: { width: 0.55, depth: 0.55 },
+      kind: 'floor-lamp',
+      visual: { color: 0x2b2b2f, accentColor: 0xffd48a, height: 1.55 },
+    },
+    {
+      id: 'upper-landing-gallery-wall',
+      category: 'plants-lighting-decor',
+      roomId: 'upperLanding',
+      position: { x: 12.8, y: 1.55, z: -31.85 },
+      orientationRadians: 0,
+      kind: 'wall-art-triptych-detail',
+      visual: { color: 0xd6c3a3, accentColor: 0x384c5c, height: 0.7 },
+    },
+    {
+      id: 'upper-landing-small-vase',
+      category: 'plants-lighting-decor',
+      roomId: 'upperLanding',
+      position: { x: 15.8, y: 1.0, z: -30.4 },
+      orientationRadians: 0,
+      kind: 'table-bowl-detail',
+      visual: { color: 0xcaa66a, accentColor: 0xf1e9da, height: 0.22 },
+    },
+    {
+      id: 'creators-studio-hanging-plant-west',
+      category: 'plants-lighting-decor',
+      roomId: 'creatorsStudio',
+      position: { x: -19.2, y: 1.75, z: -13.4 },
+      orientationRadians: 0,
+      kind: 'hanging-plant-detail',
+      visual: { color: 0x8a5a36, accentColor: 0x4f9b59, height: 0.56 },
+    },
+    {
+      id: 'creators-studio-pinboard',
+      category: 'creators-studio',
+      roomId: 'creatorsStudio',
+      position: { x: -9.2, y: 1.45, z: -31.85 },
+      orientationRadians: 0,
+      kind: 'pinboard-detail',
+      visual: { color: 0xb7834f, accentColor: 0xd8ccb8, height: 0.68 },
+    },
+    {
+      id: 'creators-studio-table-books',
+      category: 'creators-studio',
+      roomId: 'creatorsStudio',
+      position: { x: -2.8, y: 0.54, z: -19.8 },
+      orientationRadians: 0,
+      kind: 'book-stack-detail',
+      visual: { color: 0x384c5c, accentColor: 0xc29249, height: 0.22 },
+    },
+    {
+      id: 'loft-library-book-stacks',
+      category: 'loft-library',
+      roomId: 'loftLibrary',
+      position: { x: 8.2, y: 0.64, z: -9.0 },
+      orientationRadians: 0,
+      kind: 'book-stack-detail',
+      visual: { color: 0x6e7d55, accentColor: 0xc29249, height: 0.24 },
+    },
+    {
+      id: 'loft-library-wall-art',
+      category: 'loft-library',
+      roomId: 'loftLibrary',
+      position: { x: 13.0, y: 1.55, z: -15.85 },
+      orientationRadians: 0,
+      kind: 'wall-art-panel-detail',
+      visual: { color: 0xd6c3a3, accentColor: 0x42546a, height: 0.72 },
+    },
+    {
+      id: 'loft-library-hanging-vine',
+      category: 'plants-lighting-decor',
+      roomId: 'loftLibrary',
+      position: { x: 22.7, y: 1.82, z: 7.2 },
+      orientationRadians: 0,
+      kind: 'hanging-vine-detail',
+      visual: { color: 0x8a5a36, accentColor: 0x4f9b59, height: 0.7 },
+    },
+    {
+      id: 'focus-pods-cushion-scatter',
+      category: 'focus-pods',
+      roomId: 'focusPods',
+      position: { x: 19.8, y: 0.72, z: 25.0 },
+      orientationRadians: 0,
+      kind: 'cushion-scatter-detail',
+      visual: { color: 0xd8c7a7, accentColor: 0x7d6f89, height: 0.2 },
+    },
+    {
+      id: 'focus-pods-wall-planters',
+      category: 'plants-lighting-decor',
+      roomId: 'focusPods',
+      position: { x: -12.0, y: 1.45, z: 27.85 },
+      orientationRadians: 0,
+      kind: 'wall-planters-detail',
+      visual: { color: 0x8a5a36, accentColor: 0x6f9f5d, height: 0.5 },
+    },
+    {
+      id: 'focus-pods-soft-light-strip',
+      category: 'plants-lighting-decor',
+      roomId: 'focusPods',
+      position: { x: 5.0, y: 1.9, z: 27.85 },
+      orientationRadians: 0,
+      kind: 'soft-light-strip-detail',
+      visual: { color: 0x2f3740, accentColor: 0xffd48a, height: 0.12 },
+    },
+    {
       id: 'upper-landing-runner',
       category: 'upper-landing',
       roomId: 'upperLanding',
@@ -2900,12 +3109,14 @@ function createVisualDetailPrimitive(
     {
       emissive:
         definition.kind.includes('pendant') ||
-        definition.kind.includes('string-lights')
+        definition.kind.includes('string-lights') ||
+        definition.kind.includes('light-strip')
           ? (definition.visual?.accentColor ?? 0xffd48a)
           : 0x000000,
       emissiveIntensity:
         definition.kind.includes('pendant') ||
-        definition.kind.includes('string-lights')
+        definition.kind.includes('string-lights') ||
+        definition.kind.includes('light-strip')
           ? 0.35
           : 0,
     }
@@ -3001,7 +3212,12 @@ function createVisualDetailPrimitive(
 
   if (definition.kind.endsWith('-detail')) {
     const height = definition.visual?.height ?? 0.4;
-    if (definition.kind.includes('plant') || definition.kind.includes('herb')) {
+    if (
+      definition.kind.includes('plant') ||
+      definition.kind.includes('herb') ||
+      definition.kind.includes('vine') ||
+      definition.kind.includes('planters')
+    ) {
       addTinyPlantWithMaterials(
         group,
         definition.id,

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -11,6 +11,7 @@ import {
   LOWER_FLOOR_RESERVED_BLOCKERS,
   LOWER_FLOOR_ROOM_BOUNDS,
   DEFAULT_LOWER_FLOOR_FURNISHINGS,
+  DEFAULT_UPPER_FLOOR_FURNISHINGS,
   UPPER_FLOOR_RESERVED_BLOCKERS,
   UPPER_FLOOR_ROOM_BOUNDS,
   createLowerFloorFurnishings,
@@ -1612,8 +1613,8 @@ describe('upper floor furnishings foundation', () => {
     const build = createUpperFloorFurnishings();
 
     expect(build.group.name).toBe('UpperFloorFurnishings');
-    expect(build.group.children).toHaveLength(22);
-    expect(build.colliders).toHaveLength(18);
+    expect(build.group.children).toHaveLength(44);
+    expect(build.colliders).toHaveLength(29);
     expect(build.decorativeFootprints).toHaveLength(4);
   });
 
@@ -1727,6 +1728,133 @@ describe('upper floor furnishings foundation', () => {
       expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
       expectColliderBoundsToBeCloseTo(colliders, id, expected);
     });
+  });
+
+  it('adds upstairs plants, lamps, and small decor with requested P12 AABBs', () => {
+    const { colliders, group } = createUpperFloorFurnishings();
+    const expectedDecorBounds: Record<string, RectCollider> = {
+      'upper-landing-snake-plant': {
+        minX: 4.65,
+        maxX: 5.35,
+        minZ: -17.95,
+        maxZ: -17.25,
+      },
+      'upper-landing-gallery-plinth': {
+        minX: 15.35,
+        maxX: 16.25,
+        minZ: -30.85,
+        maxZ: -29.95,
+      },
+      'creators-studio-fern-stand': {
+        minX: 0.4,
+        maxX: 1.2,
+        minZ: -13.6,
+        maxZ: -12.8,
+      },
+      'creators-studio-floor-lamp': {
+        minX: -1.275,
+        maxX: -0.725,
+        minZ: -25.875,
+        maxZ: -25.325,
+      },
+      'creators-studio-tool-cart': {
+        minX: -8.6,
+        maxX: -7.4,
+        minZ: -3.4,
+        maxZ: -2.6,
+      },
+      'loft-library-window-planter': {
+        minX: 4.6,
+        maxX: 5.4,
+        minZ: 9.8,
+        maxZ: 10.6,
+      },
+      'loft-library-east-snake-plant': {
+        minX: 22.65,
+        maxX: 23.35,
+        minZ: -12.35,
+        maxZ: -11.65,
+      },
+      'loft-library-ottoman': {
+        minX: 10.55,
+        maxX: 11.45,
+        minZ: -12.05,
+        maxZ: -11.15,
+      },
+      'focus-pods-tree-planter': {
+        minX: 22.25,
+        maxX: 23.15,
+        minZ: 26.35,
+        maxZ: 27.25,
+      },
+      'focus-pods-low-plant-row-west': {
+        minX: -18.6,
+        maxX: -17.4,
+        minZ: 24.65,
+        maxZ: 25.35,
+      },
+      'focus-pods-floor-lamp': {
+        minX: 7.725,
+        maxX: 8.275,
+        minZ: 26.025,
+        maxZ: 26.575,
+      },
+    };
+
+    Object.entries(expectedDecorBounds).forEach(([id, expected]) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+      expectColliderBoundsToBeCloseTo(colliders, id, expected);
+    });
+  });
+
+  it('keeps upstairs visual-only P12 details represented and non-blocking', () => {
+    const { colliders, decorativeFootprints, group } =
+      createUpperFloorFurnishings();
+    const visualOnlyIds = [
+      'upper-landing-gallery-wall',
+      'upper-landing-small-vase',
+      'creators-studio-hanging-plant-west',
+      'creators-studio-pinboard',
+      'creators-studio-table-books',
+      'loft-library-book-stacks',
+      'loft-library-wall-art',
+      'loft-library-hanging-vine',
+      'focus-pods-cushion-scatter',
+      'focus-pods-wall-planters',
+      'focus-pods-soft-light-strip',
+    ];
+
+    visualOnlyIds.forEach((id) => {
+      expect(group.getObjectByName(`Furnishing:${id}`)).toBeDefined();
+      expect(colliders.some((collider) => collider.furnishingId === id)).toBe(
+        false
+      );
+      expect(
+        decorativeFootprints.some((footprint) => footprint.furnishingId === id)
+      ).toBe(false);
+    });
+  });
+
+  it('represents at least ten upstairs plant and greenery visuals', () => {
+    const greeneryDefinitions = DEFAULT_UPPER_FLOOR_FURNISHINGS.filter(
+      ({ id, kind }) =>
+        kind.includes('plant') ||
+        kind.includes('fern') ||
+        kind.includes('vine') ||
+        kind.includes('planter') ||
+        id.includes('plant')
+    );
+
+    expect(greeneryDefinitions.map(({ id }) => id)).toEqual(
+      expect.arrayContaining([
+        'upper-landing-snake-plant',
+        'creators-studio-fern-stand',
+        'loft-library-window-planter',
+        'loft-library-hanging-vine',
+        'focus-pods-wall-planters',
+      ])
+    );
+    expect(greeneryDefinitions.length).toBeGreaterThanOrEqual(10);
   });
 
   it('keeps the narrow loft library bookcase visual inside its collider', () => {


### PR DESCRIPTION
### Motivation
- Make the upper floor feel as lived-in and green as the downstairs pass by adding varied plants, lamps, rugs, wall art, and small tabletop/wall details while preserving existing POIs and navigation.
- Route all floor-standing solids through the existing upper-floor furnishing validation so new colliders don't block POIs, stair transitions, or reserved blockers.

### Description
- Added 11 new upstairs solid furnishing entries (snake plants, fern stand, floor lamps, gallery plinth, ottoman, tool cart, planters, herb trough) with authored footprints and expected AABBs in `src/scene/structures/lowerFloorFurnishings.ts`.
- Added 11 non-blocking visual-only detail entries (gallery wall, small vases, hanging plants, pinboard, book stacks, cushions, wall planters, soft light strip) and kept them decorative/child-only so they create no colliders.
- Extended visual-detail rendering to treat vine/planter kinds as greenery and to mark light-strip/pendant kinds as emissive so lamps/light-strips render warmth without adding dynamic lights.
- Updated unit tests in `src/tests/lowerFloorFurnishings.test.ts` to assert the expanded upstairs counts, the new P12 AABBs, non-blocking visual-only details, and a minimum count of upstairs greenery visuals, and updated the miniature manifest acknowledgement in `src/scene/miniature/*` to reflect the source-only furnishing pass.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran focused unit tests with `npm run test:ci -- lowerFloorFurnishings` which passed after the changes.
- Updated and validated the miniature manifest with `npm run miniature:manifest:update` and `npm run test:ci -- miniatureManifest`, both of which passed.
- Ran the full test suite with `npm run test:ci` (all test files passed: 182 files, 1458 tests) and `npm run build`, `npm run lint`, `npm run docs:check` (link-check produced external URL warnings), and `npm run smoke`, all of which completed successfully; `git diff --cached | ./scripts/scan-secrets.py` reported no high-risk secrets.
- Note: `npm run typecheck` still fails due to pre-existing unrelated TypeScript errors in other areas (for example `src/main.ts` and various test helpers), and those type issues were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a447b0f87f0832fb4740db2193c8f4c)