### PR TITLE
🧪 Final furnishing density QA hardening

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 33,
-      "syncNote": "Furnishing collider metadata and QA tests are source-only; tabletop furnishing proxy coverage is unchanged.",
-      "sourceFingerprint": "a6593fb159faed84a4eca87a6e0215a690335fe0c764b06bc6e72de4f798a612",
+      "syncRevision": 34,
+      "syncNote": "Greenery QA assertions are source-only; tabletop furnishing proxy coverage is unchanged.",
+      "sourceFingerprint": "e513b0c19288f2c8df177cab580ea6617252044a92cbf2e0d600fed66a012d42",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "c57fd0619d0e1342c1485ae4c1fb0fd0b7f34558148250ea93e74caf440cfe87"
+      "metadataFingerprint": "7009d9e03ef23dc72075bcf9994511fdf918a8f11751b29f8903c1ca2a4e107b"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -439,11 +439,11 @@
       "id": "decor:lower-floor-furnishings",
       "sourceFiles": ["src/scene/structures/lowerFloorFurnishings.ts"],
       "proxyFiles": [],
-      "syncRevision": 32,
-      "syncNote": "Upstairs visual detail elevation constants remain source-only until furnishing proxy coverage lands.",
-      "sourceFingerprint": "3d0aaff7574353f8f2de87f393b01092c6f869a9b18343a57bf4a22be7bdbf3b",
+      "syncRevision": 33,
+      "syncNote": "Furnishing collider metadata and QA tests are source-only; tabletop furnishing proxy coverage is unchanged.",
+      "sourceFingerprint": "a6593fb159faed84a4eca87a6e0215a690335fe0c764b06bc6e72de4f798a612",
       "proxyFingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "metadataFingerprint": "c3be91050a600975699d0ad1085fb8ff97c72bab883f88894f47d56fa9f14f22"
+      "metadataFingerprint": "c57fd0619d0e1342c1485ae4c1fb0fd0b7f34558148250ea93e74caf440cfe87"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 32,
+    syncRevision: 33,
     syncNote:
-      'Upstairs visual detail elevation constants remain source-only until furnishing proxy coverage lands.',
+      'Furnishing collider metadata and QA tests are source-only; tabletop furnishing proxy coverage is unchanged.',
     reason:
       'Lower- and upper-floor furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -83,9 +83,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
-    syncRevision: 33,
+    syncRevision: 34,
     syncNote:
-      'Furnishing collider metadata and QA tests are source-only; tabletop furnishing proxy coverage is unchanged.',
+      'Greenery QA assertions are source-only; tabletop furnishing proxy coverage is unchanged.',
     reason:
       'Lower- and upper-floor furnishings remain source-only while furnishing proxy work stays deferred until the full furnishing set lands.',
   },

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -14,6 +14,15 @@ import { isLevelSourceId } from '../level/sourceIds';
 
 export type FloorFurnishingFloorId = 'ground' | 'upper';
 
+export type FloorFurnishingPurpose =
+  | 'lower-floor-furnishing'
+  | 'upper-floor-furnishing';
+
+const FLOOR_FURNISHING_PURPOSE_BY_FLOOR = {
+  ground: 'lower-floor-furnishing',
+  upper: 'upper-floor-furnishing',
+} satisfies Record<FloorFurnishingFloorId, FloorFurnishingPurpose>;
+
 export type LowerFloorFurnishingCategory =
   | 'living-room-seating'
   | 'kitchenette'
@@ -102,7 +111,7 @@ export interface FloorFurnishingCollider<
   roomId: RoomId;
   sourceId: string;
   sourceType: 'generatedCollider';
-  purpose: 'lower-floor-furnishing' | 'upper-floor-furnishing';
+  purpose: FloorFurnishingPurpose;
   debugName: string;
   floorId: FloorFurnishingFloorId;
 }
@@ -1702,10 +1711,7 @@ function createFloorFurnishings<Category extends string, RoomId extends string>(
         roomId: definition.roomId,
         sourceId: `${floorId}.furnishings.${definition.category}.${definition.id}.generated_collider`,
         sourceType: 'generatedCollider',
-        purpose:
-          floorId === 'ground'
-            ? 'lower-floor-furnishing'
-            : 'upper-floor-furnishing',
+        purpose: FLOOR_FURNISHING_PURPOSE_BY_FLOOR[floorId],
         debugName: `${colliderDebugNamePrefix}:${definition.id}`,
         floorId,
       });

--- a/src/scene/structures/lowerFloorFurnishings.ts
+++ b/src/scene/structures/lowerFloorFurnishings.ts
@@ -101,6 +101,8 @@ export interface FloorFurnishingCollider<
   category: Category;
   roomId: RoomId;
   sourceId: string;
+  sourceType: 'generatedCollider';
+  purpose: 'lower-floor-furnishing' | 'upper-floor-furnishing';
   debugName: string;
   floorId: FloorFurnishingFloorId;
 }
@@ -1699,6 +1701,11 @@ function createFloorFurnishings<Category extends string, RoomId extends string>(
         category: definition.category,
         roomId: definition.roomId,
         sourceId: `${floorId}.furnishings.${definition.category}.${definition.id}.generated_collider`,
+        sourceType: 'generatedCollider',
+        purpose:
+          floorId === 'ground'
+            ? 'lower-floor-furnishing'
+            : 'upper-floor-furnishing',
         debugName: `${colliderDebugNamePrefix}:${definition.id}`,
         floorId,
       });

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -26,6 +26,77 @@ import {
 } from '../scene/structures/lowerFloorFurnishings';
 import type { RectCollider } from '../systems/collision';
 
+const LOWER_FLOOR_GREENERY_EXPECTATIONS = {
+  total: 18,
+  byRoom: {
+    backyard: 6,
+    kitchen: 3,
+    livingRoom: 6,
+    studio: 3,
+  },
+  byVariety: {
+    broadLeafFigMonstera: [
+      'living-room-large-plant',
+      'living-room-plant-stool',
+      'living-room-corner-fig',
+      'living-room-console-plant',
+      'kitchen-round-plant-stand',
+      'studio-monstera',
+    ],
+    pothosTrailingHangingVines: [
+      'living-room-tv-pothos-left',
+      'studio-hanging-plant-east',
+    ],
+    snakePlants: ['studio-narrow-plant-east'],
+    ferns: ['living-room-reading-plant'],
+    herbs: [
+      'kitchen-herb-planter',
+      'kitchen-counter-herb-cluster',
+      'backyard-herb-trough-north',
+    ],
+    flowers: ['backyard-flower-cluster-sw'],
+    lowPlanterRows: [
+      'backyard-planter-west-south',
+      'backyard-planter-west-north',
+      'backyard-planter-east-south',
+      'backyard-planter-east-north',
+    ],
+    treePlanters: ['living-room-corner-fig'],
+  },
+} as const;
+
+const UPPER_FLOOR_GREENERY_EXPECTATIONS = {
+  total: 13,
+  byRoom: {
+    creatorsStudio: 3,
+    focusPods: 4,
+    loftLibrary: 4,
+    upperLanding: 2,
+  },
+  byVariety: {
+    broadLeafFigMonstera: [
+      'upper-landing-planter',
+      'creators-studio-floor-plant',
+      'loft-library-planter',
+      'loft-library-window-planter',
+      'focus-pods-planter-east',
+    ],
+    pothosTrailingHangingVines: [
+      'creators-studio-hanging-plant-west',
+      'loft-library-hanging-vine',
+    ],
+    snakePlants: ['upper-landing-snake-plant', 'loft-library-east-snake-plant'],
+    ferns: ['creators-studio-fern-stand'],
+    herbs: [],
+    flowers: [],
+    lowPlanterRows: [
+      'focus-pods-low-plant-row-west',
+      'focus-pods-wall-planters',
+    ],
+    treePlanters: ['focus-pods-tree-planter'],
+  },
+} as const;
+
 const validDefinitions: LowerFloorFurnishingDefinition[] = [
   {
     id: 'living-couch-foundation',
@@ -1015,6 +1086,13 @@ describe('lower floor furnishings foundation', () => {
     });
   });
 
+  it('keeps deterministic lower-floor plant and greenery coverage', () => {
+    expectGreeneryCoverage(
+      DEFAULT_LOWER_FLOOR_FURNISHINGS,
+      LOWER_FLOOR_GREENERY_EXPECTATIONS
+    );
+  });
+
   it('keeps every default lower-floor collider finite, in-room, and disjoint', () => {
     const { colliders } = createLowerFloorFurnishings();
     const sourceIds = new Set<string>();
@@ -1024,10 +1102,14 @@ describe('lower floor furnishings foundation', () => {
       expect(sourceIds.has(collider.sourceId)).toBe(false);
       sourceIds.add(collider.sourceId);
       expect(
-        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
+        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider),
+        `${collider.furnishingId} should stay inside room ${collider.roomId}`
       ).toBe(true);
-      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
-        expect(rectanglesOverlap(collider, blocker, 0.001)).toBe(false);
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker, blockerIndex) => {
+        expect(
+          rectanglesOverlap(collider, blocker, 0.001),
+          `${collider.furnishingId} should not overlap reserved blocker ${blockerIndex}`
+        ).toBe(false);
       });
       colliders.slice(index + 1).forEach((other) => {
         expectDefaultCollidersDoNotOverlap(
@@ -1902,10 +1984,14 @@ describe('upper floor furnishings foundation', () => {
       expect(sourceIds.has(collider.sourceId)).toBe(false);
       sourceIds.add(collider.sourceId);
       expect(
-        isContainedBy(UPPER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
+        isContainedBy(UPPER_FLOOR_ROOM_BOUNDS[collider.roomId], collider),
+        `${collider.furnishingId} should stay inside room ${collider.roomId}`
       ).toBe(true);
-      UPPER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
-        expect(rectanglesOverlap(collider, blocker, 0.001)).toBe(false);
+      UPPER_FLOOR_RESERVED_BLOCKERS.forEach((blocker, blockerIndex) => {
+        expect(
+          rectanglesOverlap(collider, blocker, 0.001),
+          `${collider.furnishingId} should not overlap reserved blocker ${blockerIndex}`
+        ).toBe(false);
       });
       colliders.slice(index + 1).forEach((other) => {
         expectDefaultCollidersDoNotOverlap(
@@ -2081,6 +2167,13 @@ describe('upper floor furnishings foundation', () => {
         decorativeFootprints.some(({ furnishingId }) => furnishingId === id)
       ).toBe(false);
     });
+  });
+
+  it('keeps deterministic upper-floor plant and greenery coverage', () => {
+    expectGreeneryCoverage(
+      DEFAULT_UPPER_FLOOR_FURNISHINGS,
+      UPPER_FLOOR_GREENERY_EXPECTATIONS
+    );
   });
 
   it('creates expected custom upper source IDs and floor-routed metadata', () => {
@@ -2302,6 +2395,62 @@ function countDefinitionsByCategory(
   }, {});
 }
 
+function expectGreeneryCoverage(
+  definitions: readonly { id: string; kind: string; roomId: string }[],
+  expectations: {
+    total: number;
+    byRoom: Record<string, number>;
+    byVariety: Record<string, readonly string[]>;
+  }
+): void {
+  const expectedGreeneryIds = new Set(
+    Object.values(expectations.byVariety).flat()
+  );
+  const definitionsById = new Map(
+    definitions.map((definition) => [definition.id, definition])
+  );
+  const greeneryDefinitions = [...expectedGreeneryIds].map((id) => {
+    const definition = definitionsById.get(id);
+
+    expect(
+      definition,
+      `${id} should exist in default greenery coverage`
+    ).toBeDefined();
+    return definition;
+  });
+
+  expect(greeneryDefinitions).toHaveLength(expectations.total);
+  expect(countDefinitionsByRoom(greeneryDefinitions)).toEqual(
+    expectations.byRoom
+  );
+
+  Object.entries(expectations.byVariety).forEach(([variety, ids]) => {
+    ids.forEach((id) => {
+      const definition = definitionsById.get(id);
+
+      expect(
+        definition,
+        `${id} should exist for ${variety} greenery coverage`
+      ).toBeDefined();
+      expect(
+        expectedGreeneryIds.has(id),
+        `${id} should be counted in total greenery coverage`
+      ).toBe(true);
+    });
+  });
+}
+
+function countDefinitionsByRoom(
+  definitions: readonly ({ roomId: string } | undefined)[]
+): Record<string, number> {
+  return definitions.reduce<Record<string, number>>((counts, definition) => {
+    if (!definition) return counts;
+
+    counts[definition.roomId] = (counts[definition.roomId] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
 function expectDefaultCollidersDoNotOverlap(
   collider: FloorFurnishingCollider<string, string>,
   other: FloorFurnishingCollider<string, string>,
@@ -2325,7 +2474,11 @@ function expectDefaultCollidersDoNotOverlap(
 
   if (allowedOverlap) return;
 
-  expect(rectanglesOverlap(collider, other, 0.001)).toBe(false);
+  expect(
+    rectanglesOverlap(collider, other, 0.001),
+    `${collider.furnishingId} (${collider.category}) should not overlap ` +
+      `${other.furnishingId} (${other.category})`
+  ).toBe(false);
 }
 
 function expectFinitePositiveCollider(

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -963,6 +963,75 @@ describe('lower floor furnishings foundation', () => {
       expect(collider.sourceId).toBe(
         `ground.furnishings.${collider.category}.${collider.furnishingId}.generated_collider`
       );
+      expect(collider).toMatchObject({
+        floorId: 'ground',
+        sourceType: 'generatedCollider',
+        purpose: 'lower-floor-furnishing',
+      });
+    });
+  });
+
+  it('keeps default lower-floor inventory complete by category and collider intent', () => {
+    expect(DEFAULT_LOWER_FLOOR_FURNISHINGS).toHaveLength(75);
+    expect(countDefinitionsByCategory(DEFAULT_LOWER_FLOOR_FURNISHINGS)).toEqual(
+      {
+        backyard: 20,
+        kitchenette: 13,
+        'living-room-seating': 9,
+        'plants-lighting-decor': 17,
+        'sleeping-nook': 7,
+        storage: 9,
+      }
+    );
+
+    const { colliders, decorativeFootprints } = createLowerFloorFurnishings();
+    const solidDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.solidFootprint
+    );
+    const decorativeDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.decorativeFootprint
+    );
+    const visualOnlyDefinitions = DEFAULT_LOWER_FLOOR_FURNISHINGS.filter(
+      (definition) =>
+        !definition.solidFootprint && !definition.decorativeFootprint
+    );
+
+    expect(colliders).toHaveLength(solidDefinitions.length);
+    expect(decorativeFootprints).toHaveLength(decorativeDefinitions.length);
+    expect(new Set(colliders.map(({ furnishingId }) => furnishingId))).toEqual(
+      new Set(solidDefinitions.map(({ id }) => id))
+    );
+    expect(
+      new Set(decorativeFootprints.map(({ furnishingId }) => furnishingId))
+    ).toEqual(new Set(decorativeDefinitions.map(({ id }) => id)));
+
+    visualOnlyDefinitions.forEach(({ id }) => {
+      expect(colliders.some(({ furnishingId }) => furnishingId === id)).toBe(
+        false
+      );
+      expect(
+        decorativeFootprints.some(({ furnishingId }) => furnishingId === id)
+      ).toBe(false);
+    });
+  });
+
+  it('keeps every default lower-floor collider finite, in-room, and disjoint', () => {
+    const { colliders } = createLowerFloorFurnishings();
+    const sourceIds = new Set<string>();
+
+    colliders.forEach((collider, index) => {
+      expectFinitePositiveCollider(collider);
+      expect(sourceIds.has(collider.sourceId)).toBe(false);
+      sourceIds.add(collider.sourceId);
+      expect(
+        isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
+      ).toBe(true);
+      LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
+        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+      });
+      colliders.slice(index + 1).forEach((other) => {
+        expect(rectanglesOverlap(collider, other)).toBe(false);
+      });
     });
   });
 
@@ -1950,10 +2019,55 @@ describe('upper floor furnishings foundation', () => {
     const sourceIds = colliders.map(({ sourceId }) => sourceId);
 
     expect(new Set(sourceIds).size).toBe(sourceIds.length);
-    colliders.forEach(({ floorId, sourceId }) => {
+    colliders.forEach(({ floorId, purpose, sourceId, sourceType }) => {
       expect(isLevelSourceId(sourceId)).toBe(true);
       expect(floorId).toBe('upper');
+      expect(sourceType).toBe('generatedCollider');
+      expect(purpose).toBe('upper-floor-furnishing');
       expect(sourceId.startsWith('upper.furnishings.')).toBe(true);
+    });
+  });
+
+  it('keeps default upper-floor inventory complete by category and collider intent', () => {
+    expect(DEFAULT_UPPER_FLOOR_FURNISHINGS).toHaveLength(44);
+    expect(countDefinitionsByCategory(DEFAULT_UPPER_FLOOR_FURNISHINGS)).toEqual(
+      {
+        'creators-studio': 8,
+        'focus-pods': 6,
+        'loft-library': 7,
+        'plants-lighting-decor': 17,
+        'upper-landing': 6,
+      }
+    );
+
+    const { colliders, decorativeFootprints } = createUpperFloorFurnishings();
+    const solidDefinitions = DEFAULT_UPPER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.solidFootprint
+    );
+    const decorativeDefinitions = DEFAULT_UPPER_FLOOR_FURNISHINGS.filter(
+      (definition) => definition.decorativeFootprint
+    );
+    const visualOnlyDefinitions = DEFAULT_UPPER_FLOOR_FURNISHINGS.filter(
+      (definition) =>
+        !definition.solidFootprint && !definition.decorativeFootprint
+    );
+
+    expect(colliders).toHaveLength(solidDefinitions.length);
+    expect(decorativeFootprints).toHaveLength(decorativeDefinitions.length);
+    expect(new Set(colliders.map(({ furnishingId }) => furnishingId))).toEqual(
+      new Set(solidDefinitions.map(({ id }) => id))
+    );
+    expect(
+      new Set(decorativeFootprints.map(({ furnishingId }) => furnishingId))
+    ).toEqual(new Set(decorativeDefinitions.map(({ id }) => id)));
+
+    visualOnlyDefinitions.forEach(({ id }) => {
+      expect(colliders.some(({ furnishingId }) => furnishingId === id)).toBe(
+        false
+      );
+      expect(
+        decorativeFootprints.some(({ furnishingId }) => furnishingId === id)
+      ).toBe(false);
     });
   });
 
@@ -2165,4 +2279,24 @@ function isContainedBy(container: RectCollider, bounds: RectCollider): boolean {
     bounds.minZ >= container.minZ &&
     bounds.maxZ <= container.maxZ
   );
+}
+
+function countDefinitionsByCategory(
+  definitions: readonly { category: string }[]
+): Record<string, number> {
+  return definitions.reduce<Record<string, number>>((counts, definition) => {
+    counts[definition.category] = (counts[definition.category] ?? 0) + 1;
+    return counts;
+  }, {});
+}
+
+function expectFinitePositiveCollider(
+  collider: FloorFurnishingCollider<string, string>
+): void {
+  expect(Number.isFinite(collider.minX)).toBe(true);
+  expect(Number.isFinite(collider.maxX)).toBe(true);
+  expect(Number.isFinite(collider.minZ)).toBe(true);
+  expect(Number.isFinite(collider.maxZ)).toBe(true);
+  expect(collider.maxX - collider.minX).toBeGreaterThan(0);
+  expect(collider.maxZ - collider.minZ).toBeGreaterThan(0);
 }

--- a/src/tests/lowerFloorFurnishings.test.ts
+++ b/src/tests/lowerFloorFurnishings.test.ts
@@ -1027,10 +1027,14 @@ describe('lower floor furnishings foundation', () => {
         isContainedBy(LOWER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
       ).toBe(true);
       LOWER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
-        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+        expect(rectanglesOverlap(collider, blocker, 0.001)).toBe(false);
       });
       colliders.slice(index + 1).forEach((other) => {
-        expect(rectanglesOverlap(collider, other)).toBe(false);
+        expectDefaultCollidersDoNotOverlap(
+          collider,
+          other,
+          DEFAULT_LOWER_FLOOR_FURNISHINGS
+        );
       });
     });
   });
@@ -1888,19 +1892,27 @@ describe('upper floor furnishings foundation', () => {
     expect(visualBounds.max.z).toBeLessThanOrEqual(collider.maxZ + epsilon);
   });
 
-  it('keeps default upper solids in rooms and clear of solids and blockers', () => {
+  it('keeps every default upper-floor collider finite, in-room, and disjoint', () => {
     const { colliders } = createUpperFloorFurnishings();
+    const sourceIds = new Set<string>();
 
     colliders.forEach((collider, index) => {
+      expectFinitePositiveCollider(collider);
       expect(collider.floorId).toBe('upper');
+      expect(sourceIds.has(collider.sourceId)).toBe(false);
+      sourceIds.add(collider.sourceId);
       expect(
         isContainedBy(UPPER_FLOOR_ROOM_BOUNDS[collider.roomId], collider)
       ).toBe(true);
       UPPER_FLOOR_RESERVED_BLOCKERS.forEach((blocker) => {
-        expect(rectanglesOverlap(collider, blocker)).toBe(false);
+        expect(rectanglesOverlap(collider, blocker, 0.001)).toBe(false);
       });
       colliders.slice(index + 1).forEach((other) => {
-        expect(rectanglesOverlap(collider, other)).toBe(false);
+        expectDefaultCollidersDoNotOverlap(
+          collider,
+          other,
+          DEFAULT_UPPER_FLOOR_FURNISHINGS
+        );
       });
     });
   });
@@ -2288,6 +2300,32 @@ function countDefinitionsByCategory(
     counts[definition.category] = (counts[definition.category] ?? 0) + 1;
     return counts;
   }, {});
+}
+
+function expectDefaultCollidersDoNotOverlap(
+  collider: FloorFurnishingCollider<string, string>,
+  other: FloorFurnishingCollider<string, string>,
+  definitions: readonly {
+    id: string;
+    visual?: { allowSolidOverlapWithIds?: readonly string[] };
+  }[]
+): void {
+  const definitionById = new Map(
+    definitions.map((definition) => [definition.id, definition])
+  );
+  const colliderDefinition = definitionById.get(collider.furnishingId);
+  const otherDefinition = definitionById.get(other.furnishingId);
+  const allowedOverlap =
+    colliderDefinition?.visual?.allowSolidOverlapWithIds?.includes(
+      other.furnishingId
+    ) &&
+    otherDefinition?.visual?.allowSolidOverlapWithIds?.includes(
+      collider.furnishingId
+    );
+
+  if (allowedOverlap) return;
+
+  expect(rectanglesOverlap(collider, other, 0.001)).toBe(false);
 }
 
 function expectFinitePositiveCollider(


### PR DESCRIPTION
### Motivation
- Complete the final density QA pass by making furnishing collider metadata explicit and increasing regression coverage for furnishing inventory, collider correctness, and visual-only details.
- Ensure generated colliders carry clear floor/routing metadata so runtime registration and audits can reliably distinguish ground vs upper fixtures.
- Keep tabletop/miniature proxies unchanged while acknowledging source-only metadata/test changes in the miniature manifest.

### Description
- Add `sourceType` and `purpose` fields to generated furnishing colliders and surface the relevant `floorId` routing when building colliders in `src/scene/structures/lowerFloorFurnishings.ts`.
- Strengthen furnishing tests in `src/tests/lowerFloorFurnishings.test.ts` to assert inventory totals by category, decorative vs visual-only intent, finite positive AABBs, room containment, reserved-blocker clearance, no solid/solid overlaps, unique/valid `sourceId`s, and floor-routed collider metadata for both lower and upper floors.
- Bump the furnishing entry in `src/scene/miniature/sceneComponentRegistry.ts` and update `src/scene/miniature/miniatureManifest.generated.json` `syncRevision`/`syncNote` so miniature manifest checks remain green for this source-only change.
- Changes are intentionally focused and scoped to furnishing collider metadata, tests, and manifest acknowledgement (no new furnishing system or POI moves).

### Testing
- Ran formatting with `npm run format:write` (passed) and lint with `npm run lint` (passed).
- Ran focused tests `npm run test:ci -- lowerFloorFurnishings` and full suite `npm run test:ci`, both passed (new/updated furnishing tests included): `lowerFloorFurnishings` passed and full test run completed with all suites green after updating the miniature manifest.
- Ran `npm run docs:check` (passed, link checks warn about external fetches) and `npm run smoke` (passed, which runs `npm run build` and `scripts/assert-dist.cjs`).
- Updated the miniature manifest using `npm run miniature:manifest:update` and committed the `syncRevision`/`syncNote` updates so `npm run test:ci` and `npm run miniature:check` succeed.

Notes / residual risks
- `npm run typecheck` still reports unrelated repository-wide TypeScript issues that predate this change (these are not introduced by this PR). The typecheck failure is acknowledged in CI/local logs but is out of scope for this focused QA hardening.
- Runtime collider inspection via `npm run collider:inspect` was attempted but blocked in this environment because Playwright browsers are not installed (`npx playwright install` would be required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44b8489eec832f9a2cb5ac24b2ceb3)