### PR TITLE
🖼️ : – Add immersive wall paintings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -345,6 +345,10 @@ import {
   createUpperStairwellLanding,
   type UpperStairwellLandingCollider,
 } from './scene/structures/upperStairwellLanding';
+import {
+  createWallPaintings,
+  type WallPaintingsBuild,
+} from './scene/structures/wallPaintings';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
   createWoveLoom,
@@ -1109,6 +1113,7 @@ const mediaWallStarBridge = createMediaWallStarBridge();
 let livingRoomMediaWall: LivingRoomMediaWallBuild | null = null;
 let futuroptimistTvModelRoot: Object3D | null = null;
 let selfieMirror: SelfieMirrorBuild | null = null;
+let wallPaintings: WallPaintingsBuild | null = null;
 let ledStripGroup: Group | null = null;
 let ledFillLightGroup: Group | null = null;
 const ledStripMaterials: MeshStandardMaterial[] = [];
@@ -2277,6 +2282,10 @@ function initializeImmersiveScene(
     playerRadius: PLAYER_RADIUS,
     guardThickness: stairGuardThickness,
   }).forEach(registerSafetyCollider);
+
+  wallPaintings = createWallPaintings();
+  groundStructureGroup.add(wallPaintings.groundGroup);
+  upperStructureGroup.add(wallPaintings.upperGroup);
 
   const lowerFloorFurnishings = createLowerFloorFurnishings();
   groundStructureGroup.add(lowerFloorFurnishings.group);
@@ -7069,6 +7078,10 @@ function initializeImmersiveScene(
     if (selfieMirror) {
       selfieMirror.dispose();
       selfieMirror = null;
+    }
+    if (wallPaintings) {
+      wallPaintings.dispose();
+      wallPaintings = null;
     }
     if (flywheelShowpiece) {
       flywheelShowpiece.dispose();

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 3,
-      "syncNote": "Kitchen painting was raised on its wall; tabletop proxy geometry remains representative.",
-      "sourceFingerprint": "72b8782ee9a4c7c733a097a0c36d17c92631f227dd7f58897e0cd9a2fb46d0f6",
+      "syncRevision": 4,
+      "syncNote": "Rocket painting moved above the dresser; tabletop proxy geometry remains representative.",
+      "sourceFingerprint": "e8f42399d72fcf67ce340ecaed0a8b0d47dc4728714f9beeb4dc64eab341810e",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "6997f2bd7f4dac2fe83dac35932825c72fe3ac1549aa50436f3e2ffa21127160"
+      "metadataFingerprint": "fddb15f9eeb5537e318306b25edccfee160e8566fe58249a39767ffaf3275897"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 6,
-      "syncNote": "Rocket painting uses frame half-width math to center over the dresser; tabletop proxy remains representative.",
-      "sourceFingerprint": "9b11aefac2e19023103892ea2e89c73892d5cc4c15aaa270508fe931fbb5717d",
+      "syncRevision": 7,
+      "syncNote": "Rocket painting centers from lower-floor dresser geometry; tabletop proxy remains representative.",
+      "sourceFingerprint": "8052d484dae79091f130b5dd6b1046e1766192c76daeebb8121980f2a2e7b688",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "d9fce55d62f37a6afed11c928c3a084d82b285a51cc73d3ed2f3b1e9db4ef95c"
+      "metadataFingerprint": "14e481b46b87fb83b80c778d7c90afa78f06b10e61f62c58b6271b840bfe17c3"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 4,
-      "syncNote": "Rocket painting moved above the dresser; tabletop proxy geometry remains representative.",
-      "sourceFingerprint": "e8f42399d72fcf67ce340ecaed0a8b0d47dc4728714f9beeb4dc64eab341810e",
+      "syncRevision": 5,
+      "syncNote": "Rocket painting centered over the dresser; tabletop proxy geometry remains representative.",
+      "sourceFingerprint": "f243492c52329688443f5e28788efc3748e6e6b20e5da6a7b06f2f8f36e2fe54",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "fddb15f9eeb5537e318306b25edccfee160e8566fe58249a39767ffaf3275897"
+      "metadataFingerprint": "131881d8bb94c444b63119589b047321f6f3784f82017c4222bc9e6950e1f026"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 2,
-      "syncNote": "Living-room painting placement moved away from the media-wall POI; tabletop proxy geometry remains representative.",
-      "sourceFingerprint": "ad3a5072e9f1ccf33dc595f14c8d5f6f7b0a9f4d97d14291ee06887987cc3f20",
+      "syncRevision": 3,
+      "syncNote": "Kitchen painting was raised on its wall; tabletop proxy geometry remains representative.",
+      "sourceFingerprint": "72b8782ee9a4c7c733a097a0c36d17c92631f227dd7f58897e0cd9a2fb46d0f6",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "bb719f67d8fd8c101b1fe58b71e3916efc5489de2f457a3e54ff6429841ff50e"
+      "metadataFingerprint": "6997f2bd7f4dac2fe83dac35932825c72fe3ac1549aa50436f3e2ffa21127160"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -446,6 +446,16 @@
       "metadataFingerprint": "7009d9e03ef23dc72075bcf9994511fdf918a8f11751b29f8903c1ca2a4e107b"
     },
     {
+      "id": "decor:wall-paintings",
+      "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "syncRevision": 1,
+      "syncNote": "Wall paintings are represented by simplified framed panels so the tabletop preserves the new visual anchors.",
+      "sourceFingerprint": "a012d17110d5d25b5e886c2c9882790a7468d1da6830da11dd8d8c44c352abc9",
+      "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
+      "metadataFingerprint": "1b0709a527d2854aa37836cdc40a90191d536f4cd8a6f5f68593ba11c1a41905"
+    },
+    {
       "id": "environment:backyard",
       "sourceFiles": ["src/scene/environments/backyard.ts"],
       "proxyFiles": [],

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 7,
-      "syncNote": "Rocket painting centers from lower-floor dresser geometry; tabletop proxy remains representative.",
-      "sourceFingerprint": "8052d484dae79091f130b5dd6b1046e1766192c76daeebb8121980f2a2e7b688",
+      "syncRevision": 8,
+      "syncNote": "Wall-painting API cleanup keeps the same representative tabletop proxy geometry.",
+      "sourceFingerprint": "06ac3d14e53d098f7583918a19563c1b78166069f540e232ba8ab73d4667c3f8",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "14e481b46b87fb83b80c778d7c90afa78f06b10e61f62c58b6271b840bfe17c3"
+      "metadataFingerprint": "2bcc02f8f0a71e3f95f9bdda15b0cf21f9cb1ef8f24ace7bf5b08566db87dde7"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 5,
-      "syncNote": "Rocket painting centered over the dresser; tabletop proxy geometry remains representative.",
-      "sourceFingerprint": "f243492c52329688443f5e28788efc3748e6e6b20e5da6a7b06f2f8f36e2fe54",
+      "syncRevision": 6,
+      "syncNote": "Rocket painting uses frame half-width math to center over the dresser; tabletop proxy remains representative.",
+      "sourceFingerprint": "9b11aefac2e19023103892ea2e89c73892d5cc4c15aaa270508fe931fbb5717d",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "131881d8bb94c444b63119589b047321f6f3784f82017c4222bc9e6950e1f026"
+      "metadataFingerprint": "d9fce55d62f37a6afed11c928c3a084d82b285a51cc73d3ed2f3b1e9db4ef95c"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 1,
-      "syncNote": "Wall paintings are represented by simplified framed panels so the tabletop preserves the new visual anchors.",
-      "sourceFingerprint": "a012d17110d5d25b5e886c2c9882790a7468d1da6830da11dd8d8c44c352abc9",
+      "syncRevision": 2,
+      "syncNote": "Living-room painting placement moved away from the media-wall POI; tabletop proxy geometry remains representative.",
+      "sourceFingerprint": "ad3a5072e9f1ccf33dc595f14c8d5f6f7b0a9f4d97d14291ee06887987cc3f20",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "1b0709a527d2854aa37836cdc40a90191d536f4cd8a6f5f68593ba11c1a41905"
+      "metadataFingerprint": "bb719f67d8fd8c101b1fe58b71e3916efc5489de2f457a3e54ff6429841ff50e"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 5,
+    syncRevision: 6,
     syncNote:
-      'Rocket painting centered over the dresser; tabletop proxy geometry remains representative.',
+      'Rocket painting uses frame half-width math to center over the dresser; tabletop proxy remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 1,
+    syncRevision: 2,
     syncNote:
-      'Wall paintings are represented by simplified framed panels so the tabletop preserves the new visual anchors.',
+      'Living-room painting placement moved away from the media-wall POI; tabletop proxy geometry remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -80,6 +80,15 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     syncNote: 'Ceiling panel fixtures need simplified caps in the tabletop.',
   },
   {
+    id: 'decor:wall-paintings',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/wallPaintings.ts'],
+    proxyFiles: [SELF_FILE],
+    syncRevision: 1,
+    syncNote:
+      'Wall paintings are represented by simplified framed panels so the tabletop preserves the new visual anchors.',
+  },
+  {
     id: 'decor:lower-floor-furnishings',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/lowerFloorFurnishings.ts'],
@@ -496,6 +505,31 @@ export const MINIATURE_SCENE_COMPONENT_PROXIES: readonly MiniatureProxyDefinitio
           size: [1, 0.025, 0.7],
           position: [0, 0.25, 0],
           color: 0xe2e8f0,
+        },
+      ],
+    },
+    {
+      id: 'component:wall-paintings',
+      displayName: 'Wall painting proxy',
+      syncRevision: 1,
+      syncNote: 'Simplified framed wall paintings.',
+      sourceFiles: ['src/scene/structures/wallPaintings.ts'],
+      proxyFiles: [SELF_FILE],
+      primitives: [
+        {
+          kind: 'box',
+          name: 'miniature-wall-painting-frame',
+          size: [0.62, 0.04, 0.48],
+          position: [0, 0.54, 0],
+          color: 0x6a4a2f,
+        },
+        {
+          kind: 'plane',
+          name: 'miniature-wall-painting-image',
+          size: [0.46, 0, 0.34],
+          position: [0, 0.545, 0.021],
+          rotation: [0, 0, 0],
+          color: 0xdbeafe,
         },
       ],
     },

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 6,
+    syncRevision: 7,
     syncNote:
-      'Rocket painting uses frame half-width math to center over the dresser; tabletop proxy remains representative.',
+      'Rocket painting centers from lower-floor dresser geometry; tabletop proxy remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 2,
+    syncRevision: 3,
     syncNote:
-      'Living-room painting placement moved away from the media-wall POI; tabletop proxy geometry remains representative.',
+      'Kitchen painting was raised on its wall; tabletop proxy geometry remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 7,
+    syncRevision: 8,
     syncNote:
-      'Rocket painting centers from lower-floor dresser geometry; tabletop proxy remains representative.',
+      'Wall-painting API cleanup keeps the same representative tabletop proxy geometry.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 3,
+    syncRevision: 4,
     syncNote:
-      'Kitchen painting was raised on its wall; tabletop proxy geometry remains representative.',
+      'Rocket painting moved above the dresser; tabletop proxy geometry remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 4,
+    syncRevision: 5,
     syncNote:
-      'Rocket painting moved above the dresser; tabletop proxy geometry remains representative.',
+      'Rocket painting centered over the dresser; tabletop proxy geometry remains representative.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { WALL_PAINTING_CONFIGS } from '../wallPaintings';
+
+const EXPECTED_IMAGE_PATHS = [
+  '/images/3dprinted_rocket_nosecone.jpg',
+  '/images/3dprinter.jpg',
+  '/images/democratizedspace.jpg',
+  '/images/hydroponic_lamp.jpg',
+  '/images/hypercar_grassy.jpg',
+  '/images/launch.jpg',
+] as const;
+
+describe('WALL_PAINTING_CONFIGS', () => {
+  it('places exactly one painting for each public image asset', () => {
+    expect(WALL_PAINTING_CONFIGS).toHaveLength(EXPECTED_IMAGE_PATHS.length);
+    expect(
+      WALL_PAINTING_CONFIGS.map((config) => config.imagePath).sort()
+    ).toEqual([...EXPECTED_IMAGE_PATHS].sort());
+  });
+
+  it('keeps paintings on visible west or north walls across both floors', () => {
+    expect(
+      WALL_PAINTING_CONFIGS.filter((config) => config.floor === 'ground')
+    ).toHaveLength(3);
+    expect(
+      WALL_PAINTING_CONFIGS.filter((config) => config.floor === 'upper')
+    ).toHaveLength(3);
+
+    expect(
+      new Set(WALL_PAINTING_CONFIGS.map((config) => config.wallOrientation))
+    ).toEqual(new Set(['north', 'west']));
+    expect(
+      WALL_PAINTING_CONFIGS.every((config) =>
+        ['north', 'west'].includes(config.wallOrientation)
+      )
+    ).toBe(true);
+  });
+
+  it('varies the frame treatments while keeping square image dimensions', () => {
+    const variants = new Set(
+      WALL_PAINTING_CONFIGS.map((config) =>
+        [
+          config.frame.frameColor,
+          config.frame.matColor,
+          config.frame.frameThickness,
+          config.frame.frameDepth,
+          config.frame.matBorder,
+          config.size,
+        ].join(':')
+      )
+    );
+
+    expect(variants.size).toBe(WALL_PAINTING_CONFIGS.length);
+    expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
+  });
+});

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { WALL_PAINTING_CONFIGS } from '../wallPaintings';
+import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from '../lowerFloorFurnishings';
+import { WALL_PAINTING_CONFIGS, getFurnishingCenter } from '../wallPaintings';
 
 const EXPECTED_IMAGE_PATHS = [
   '/images/3dprinted_rocket_nosecone.jpg',
@@ -37,21 +38,20 @@ describe('WALL_PAINTING_CONFIGS', () => {
     ).toBe(true);
   });
 
-  it('centers the dresser painting by accounting for the anchored frame edge', () => {
-    const dresserCenterX = -24;
+  it('centers the dresser painting from lower-floor furnishing geometry', () => {
+    const dresser = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
+      (definition) => definition.id === 'living-room-south-bookcase-west'
+    );
     const rocketPainting = WALL_PAINTING_CONFIGS.find(
       (config) => config.id === 'rocket-nosecone-living-room-north'
     );
 
+    expect(dresser?.solidBounds).toBeDefined();
     expect(rocketPainting).toBeDefined();
-    const frameSize =
-      rocketPainting!.size +
-      rocketPainting!.frame.matBorder * 2 +
-      rocketPainting!.frame.frameThickness * 2;
 
-    expect(rocketPainting!.position.x + frameSize / 2).toBeCloseTo(
-      dresserCenterX
-    );
+    const dresserCenter = getFurnishingCenter(dresser!.id);
+    expect(rocketPainting!.position.x).toBeCloseTo(dresserCenter.x);
+    expect(rocketPainting!.position.z).toBeCloseTo(dresserCenter.z);
   });
 
   it('varies the frame treatments while keeping square image dimensions', () => {

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -37,6 +37,23 @@ describe('WALL_PAINTING_CONFIGS', () => {
     ).toBe(true);
   });
 
+  it('centers the dresser painting by accounting for the anchored frame edge', () => {
+    const dresserCenterX = -24;
+    const rocketPainting = WALL_PAINTING_CONFIGS.find(
+      (config) => config.id === 'rocket-nosecone-living-room-north'
+    );
+
+    expect(rocketPainting).toBeDefined();
+    const frameSize =
+      rocketPainting!.size +
+      rocketPainting!.frame.matBorder * 2 +
+      rocketPainting!.frame.frameThickness * 2;
+
+    expect(rocketPainting!.position.x + frameSize / 2).toBeCloseTo(
+      dresserCenterX
+    );
+  });
+
   it('varies the frame treatments while keeping square image dimensions', () => {
     const variants = new Set(
       WALL_PAINTING_CONFIGS.map((config) =>

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -68,7 +68,7 @@ describe('WALL_PAINTING_CONFIGS', () => {
       )
     );
 
-    expect(variants.size).toBe(WALL_PAINTING_CONFIGS.length);
+    expect(variants.size).toBeGreaterThan(1);
     expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
   });
 });

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -62,7 +62,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'ground',
     room: 'living room',
     wallOrientation: 'north',
-    position: { x: -24.11, y: 2.5, z: -30.06 },
+    position: { x: -24, y: 2.5, z: -30.06 },
     size: 2.15,
     frame: {
       frameColor: 0x4f3528,

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -52,13 +52,13 @@ const UPPER_PAINTING_CENTER_Y = UPPER_FLOOR_TOP_ELEVATION + 2.2;
 
 export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
   {
-    id: 'rocket-nosecone-living-room-west',
+    id: 'rocket-nosecone-living-room-north',
     label: '3D printed rocket nosecone',
     imagePath: '/images/3dprinted_rocket_nosecone.jpg',
     floor: 'ground',
     room: 'living room',
-    wallOrientation: 'west',
-    position: { x: -31.92, z: -20.2 },
+    wallOrientation: 'north',
+    position: { x: -28.57, z: -31.23 },
     size: 2.15,
     frame: {
       frameColor: 0x4f3528,

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -1,0 +1,324 @@
+import {
+  BoxGeometry,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  PlaneGeometry,
+  SRGBColorSpace,
+  TextureLoader,
+  type ColorRepresentation,
+  type Material,
+  type Texture,
+} from 'three';
+
+import { UPPER_FLOOR_TOP_ELEVATION } from '../level/floorElevations';
+
+export type WallPaintingFloor = 'ground' | 'upper';
+export type WallPaintingOrientation = 'north' | 'west';
+
+export interface WallPaintingFrameVariant {
+  readonly frameColor: ColorRepresentation;
+  readonly matColor: ColorRepresentation;
+  readonly frameThickness: number;
+  readonly frameDepth: number;
+  readonly matBorder: number;
+  readonly backingDepth?: number;
+}
+
+export interface WallPaintingConfig {
+  readonly id: string;
+  readonly label: string;
+  readonly imagePath: `/images/${string}`;
+  readonly floor: WallPaintingFloor;
+  readonly room: string;
+  readonly wallOrientation: WallPaintingOrientation;
+  readonly position: { readonly x: number; readonly z: number };
+  readonly size: number;
+  readonly frame: WallPaintingFrameVariant;
+}
+
+export interface WallPaintingsBuild {
+  readonly group: Group;
+  readonly groundGroup: Group;
+  readonly upperGroup: Group;
+  readonly configs: readonly WallPaintingConfig[];
+  dispose(): void;
+}
+
+const WALL_OFFSET = 0.08;
+const GROUND_PAINTING_CENTER_Y = 2.35;
+const UPPER_PAINTING_CENTER_Y = UPPER_FLOOR_TOP_ELEVATION + 2.2;
+
+export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
+  {
+    id: 'rocket-nosecone-living-room-west',
+    label: '3D printed rocket nosecone',
+    imagePath: '/images/3dprinted_rocket_nosecone.jpg',
+    floor: 'ground',
+    room: 'living room',
+    wallOrientation: 'west',
+    position: { x: -31.92, z: -20.2 },
+    size: 2.15,
+    frame: {
+      frameColor: 0x4f3528,
+      matColor: 0xe8dfcf,
+      frameThickness: 0.16,
+      frameDepth: 0.16,
+      matBorder: 0.18,
+    },
+  },
+  {
+    id: 'hydroponic-lamp-kitchen-west',
+    label: 'Hydroponic lamp',
+    imagePath: '/images/hydroponic_lamp.jpg',
+    floor: 'ground',
+    room: 'kitchen',
+    wallOrientation: 'west',
+    position: { x: -31.92, z: 2.7 },
+    size: 1.85,
+    frame: {
+      frameColor: 0x556b4f,
+      matColor: 0xf0ead8,
+      frameThickness: 0.13,
+      frameDepth: 0.2,
+      matBorder: 0.14,
+    },
+  },
+  {
+    id: 'launch-studio-north',
+    label: 'Launch',
+    imagePath: '/images/launch.jpg',
+    floor: 'ground',
+    room: 'studio',
+    wallOrientation: 'north',
+    position: { x: 5.2, z: -7.92 },
+    size: 2.0,
+    frame: {
+      frameColor: 0x25354f,
+      matColor: 0xd9e2ee,
+      frameThickness: 0.19,
+      frameDepth: 0.14,
+      matBorder: 0.12,
+      backingDepth: 0.08,
+    },
+  },
+  {
+    id: 'democratized-space-creators-studio-west',
+    label: 'Democratized space',
+    imagePath: '/images/democratizedspace.jpg',
+    floor: 'upper',
+    room: 'creators studio',
+    wallOrientation: 'west',
+    position: { x: -19.92, z: -12.2 },
+    size: 2.25,
+    frame: {
+      frameColor: 0x6d4c2f,
+      matColor: 0xefe4ca,
+      frameThickness: 0.14,
+      frameDepth: 0.18,
+      matBorder: 0.22,
+    },
+  },
+  {
+    id: '3d-printer-loft-library-west',
+    label: '3D printer',
+    imagePath: '/images/3dprinter.jpg',
+    floor: 'upper',
+    room: 'loft library',
+    wallOrientation: 'west',
+    position: { x: 4.08, z: -3.2 },
+    size: 1.9,
+    frame: {
+      frameColor: 0x2f3033,
+      matColor: 0xe7e0d2,
+      frameThickness: 0.18,
+      frameDepth: 0.12,
+      matBorder: 0.16,
+    },
+  },
+  {
+    id: 'hypercar-focus-pods-north',
+    label: 'Hypercar on grass',
+    imagePath: '/images/hypercar_grassy.jpg',
+    floor: 'upper',
+    room: 'focus pods',
+    wallOrientation: 'north',
+    position: { x: -3.8, z: 27.92 },
+    size: 2.1,
+    frame: {
+      frameColor: 0x6a7258,
+      matColor: 0xf2eadb,
+      frameThickness: 0.12,
+      frameDepth: 0.22,
+      matBorder: 0.2,
+      backingDepth: 0.1,
+    },
+  },
+] as const;
+
+export function createWallPaintings(
+  configs: readonly WallPaintingConfig[] = WALL_PAINTING_CONFIGS
+): WallPaintingsBuild {
+  const group = new Group();
+  group.name = 'WallPaintings';
+  const groundGroup = new Group();
+  groundGroup.name = 'GroundWallPaintings';
+  const upperGroup = new Group();
+  upperGroup.name = 'UpperWallPaintings';
+  group.add(groundGroup, upperGroup);
+
+  const textureLoader = new TextureLoader();
+  const textures: Texture[] = [];
+  const materials: Material[] = [];
+  const geometries: Array<BoxGeometry | PlaneGeometry> = [];
+
+  configs.forEach((config) => {
+    const painting = createWallPainting(
+      config,
+      textureLoader,
+      textures,
+      materials,
+      geometries
+    );
+    const floorGroup = config.floor === 'upper' ? upperGroup : groundGroup;
+    floorGroup.add(painting);
+  });
+
+  return {
+    group,
+    groundGroup,
+    upperGroup,
+    configs,
+    dispose() {
+      textures.forEach((texture) => texture.dispose());
+      materials.forEach((material) => material.dispose());
+      geometries.forEach((geometry) => geometry.dispose());
+    },
+  };
+}
+
+function createWallPainting(
+  config: WallPaintingConfig,
+  textureLoader: TextureLoader,
+  textures: Texture[],
+  materials: Material[],
+  geometries: Array<BoxGeometry | PlaneGeometry>
+): Group {
+  const group = new Group();
+  group.name = `WallPainting:${config.id}`;
+
+  const imageTexture = textureLoader.load(config.imagePath);
+  imageTexture.colorSpace = SRGBColorSpace;
+  imageTexture.name = `WallPaintingTexture:${config.id}`;
+  textures.push(imageTexture);
+
+  const imageMaterial = new MeshBasicMaterial({
+    map: imageTexture,
+    toneMapped: false,
+  });
+  const matMaterial = new MeshStandardMaterial({
+    color: config.frame.matColor,
+    roughness: 0.72,
+  });
+  const frameMaterial = new MeshStandardMaterial({
+    color: config.frame.frameColor,
+    roughness: 0.58,
+    metalness: 0.08,
+  });
+  const backingMaterial = new MeshStandardMaterial({
+    color: 0x2d2b29,
+    roughness: 0.84,
+  });
+  materials.push(imageMaterial, matMaterial, frameMaterial, backingMaterial);
+
+  const imageSize = config.size;
+  const matSize = imageSize + config.frame.matBorder * 2;
+  const frameSize = matSize + config.frame.frameThickness * 2;
+  const backingDepth = config.frame.backingDepth ?? 0.06;
+
+  const backingGeometry = new BoxGeometry(frameSize, frameSize, backingDepth);
+  const matGeometry = new PlaneGeometry(matSize, matSize);
+  const imageGeometry = new PlaneGeometry(imageSize, imageSize);
+  geometries.push(backingGeometry, matGeometry, imageGeometry);
+
+  const backing = new Mesh(backingGeometry, backingMaterial);
+  backing.name = `${group.name}:backing`;
+  group.add(backing);
+
+  const mat = new Mesh(matGeometry, matMaterial);
+  mat.name = `${group.name}:mat`;
+  mat.position.z = backingDepth / 2 + 0.006;
+  group.add(mat);
+
+  const image = new Mesh(imageGeometry, imageMaterial);
+  image.name = `${group.name}:image`;
+  image.position.z = mat.position.z + 0.006;
+  group.add(image);
+
+  addFrameRails(
+    group,
+    frameSize,
+    matSize,
+    config.frame,
+    frameMaterial,
+    geometries
+  );
+  placeOnWall(group, config);
+
+  return group;
+}
+
+function addFrameRails(
+  group: Group,
+  frameSize: number,
+  matSize: number,
+  frame: WallPaintingFrameVariant,
+  material: MeshStandardMaterial,
+  geometries: Array<BoxGeometry | PlaneGeometry>
+): void {
+  const railDepth = frame.frameDepth;
+  const railThickness = frame.frameThickness;
+  const sideRailGeometry = new BoxGeometry(railThickness, frameSize, railDepth);
+  const topRailGeometry = new BoxGeometry(matSize, railThickness, railDepth);
+  geometries.push(sideRailGeometry, topRailGeometry);
+
+  const halfOffset = matSize / 2 + railThickness / 2;
+  const rails = [
+    { name: 'left-rail', x: -halfOffset, y: 0, geometry: sideRailGeometry },
+    { name: 'right-rail', x: halfOffset, y: 0, geometry: sideRailGeometry },
+    { name: 'top-rail', x: 0, y: halfOffset, geometry: topRailGeometry },
+    { name: 'bottom-rail', x: 0, y: -halfOffset, geometry: topRailGeometry },
+  ];
+
+  rails.forEach((rail) => {
+    const mesh = new Mesh(rail.geometry, material);
+    mesh.name = `${group.name}:${rail.name}`;
+    mesh.position.set(rail.x, rail.y, railDepth / 2);
+    group.add(mesh);
+  });
+}
+
+function placeOnWall(group: Group, config: WallPaintingConfig): void {
+  const centerY =
+    config.floor === 'upper'
+      ? UPPER_PAINTING_CENTER_Y
+      : GROUND_PAINTING_CENTER_Y;
+  const wallOffset = WALL_OFFSET + config.frame.frameDepth / 2;
+
+  if (config.wallOrientation === 'west') {
+    group.position.set(
+      config.position.x + wallOffset,
+      centerY,
+      config.position.z
+    );
+    group.rotation.y = Math.PI / 2;
+    return;
+  }
+
+  group.position.set(
+    config.position.x,
+    centerY,
+    config.position.z + wallOffset
+  );
+}

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -138,13 +138,13 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     },
   },
   {
-    id: 'hypercar-focus-pods-north',
+    id: 'hypercar-focus-pods-west',
     label: 'Hypercar on grass',
     imagePath: '/images/hypercar_grassy.jpg',
     floor: 'upper',
     room: 'focus pods',
-    wallOrientation: 'north',
-    position: { x: -3.8, z: 27.92 },
+    wallOrientation: 'west',
+    position: { x: -19.92, z: 20.0 },
     size: 2.1,
     frame: {
       frameColor: 0x6a7258,

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -62,7 +62,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'ground',
     room: 'living room',
     wallOrientation: 'north',
-    position: { x: -28.57, z: -31.23 },
+    position: { x: -24.11, y: 2.5, z: -30.06 },
     size: 2.15,
     frame: {
       frameColor: 0x4f3528,

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -33,7 +33,11 @@ export interface WallPaintingConfig {
   readonly floor: WallPaintingFloor;
   readonly room: string;
   readonly wallOrientation: WallPaintingOrientation;
-  readonly position: { readonly x: number; readonly z: number };
+  readonly position: {
+    readonly x: number;
+    readonly y?: number;
+    readonly z: number;
+  };
   readonly size: number;
   readonly frame: WallPaintingFrameVariant;
 }
@@ -75,7 +79,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'ground',
     room: 'kitchen',
     wallOrientation: 'west',
-    position: { x: -31.92, z: 2.7 },
+    position: { x: -31.92, y: 0.35, z: 2.7 },
     size: 1.85,
     frame: {
       frameColor: 0x556b4f,
@@ -300,10 +304,11 @@ function addFrameRails(
 }
 
 function placeOnWall(group: Group, config: WallPaintingConfig): void {
-  const centerY =
+  const baseCenterY =
     config.floor === 'upper'
       ? UPPER_PAINTING_CENTER_Y
       : GROUND_PAINTING_CENTER_Y;
+  const centerY = baseCenterY + (config.position.y ?? 0);
   const wallOffset = WALL_OFFSET + config.frame.frameDepth / 2;
 
   if (config.wallOrientation === 'west') {

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -37,6 +37,7 @@ export interface WallPaintingConfig {
   readonly wallOrientation: WallPaintingOrientation;
   readonly position: {
     readonly x: number;
+    // Optional additive offset from the floor's default painting center height.
     readonly y?: number;
     readonly z: number;
   };
@@ -45,7 +46,6 @@ export interface WallPaintingConfig {
 }
 
 export interface WallPaintingsBuild {
-  readonly group: Group;
   readonly groundGroup: Group;
   readonly upperGroup: Group;
   readonly configs: readonly WallPaintingConfig[];
@@ -53,6 +53,7 @@ export interface WallPaintingsBuild {
 }
 
 const WALL_OFFSET = 0.08;
+const DEFAULT_BACKING_DEPTH = 0.06;
 const GROUND_PAINTING_CENTER_Y = 2.35;
 const UPPER_PAINTING_CENTER_Y = UPPER_FLOOR_TOP_ELEVATION + 2.2;
 const ROCKET_NOSECONE_DRESSER_ID = 'living-room-south-bookcase-west';
@@ -193,13 +194,10 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
 export function createWallPaintings(
   configs: readonly WallPaintingConfig[] = WALL_PAINTING_CONFIGS
 ): WallPaintingsBuild {
-  const group = new Group();
-  group.name = 'WallPaintings';
   const groundGroup = new Group();
   groundGroup.name = 'GroundWallPaintings';
   const upperGroup = new Group();
   upperGroup.name = 'UpperWallPaintings';
-  group.add(groundGroup, upperGroup);
 
   const textureLoader = new TextureLoader();
   const textures: Texture[] = [];
@@ -219,7 +217,6 @@ export function createWallPaintings(
   });
 
   return {
-    group,
     groundGroup,
     upperGroup,
     configs,
@@ -268,7 +265,7 @@ function createWallPainting(
   const imageSize = config.size;
   const matSize = imageSize + config.frame.matBorder * 2;
   const frameSize = matSize + config.frame.frameThickness * 2;
-  const backingDepth = config.frame.backingDepth ?? 0.06;
+  const backingDepth = config.frame.backingDepth ?? DEFAULT_BACKING_DEPTH;
 
   const backingGeometry = new BoxGeometry(frameSize, frameSize, backingDepth);
   const matGeometry = new PlaneGeometry(matSize, matSize);
@@ -338,7 +335,8 @@ function placeOnWall(group: Group, config: WallPaintingConfig): void {
       ? UPPER_PAINTING_CENTER_Y
       : GROUND_PAINTING_CENTER_Y;
   const centerY = baseCenterY + (config.position.y ?? 0);
-  const wallOffset = WALL_OFFSET + config.frame.frameDepth / 2;
+  const backingDepth = config.frame.backingDepth ?? DEFAULT_BACKING_DEPTH;
+  const wallOffset = WALL_OFFSET + backingDepth / 2;
 
   if (config.wallOrientation === 'west') {
     group.position.set(

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -53,6 +53,10 @@ export interface WallPaintingsBuild {
 const WALL_OFFSET = 0.08;
 const GROUND_PAINTING_CENTER_Y = 2.35;
 const UPPER_PAINTING_CENTER_Y = UPPER_FLOOR_TOP_ELEVATION + 2.2;
+const ROCKET_NOSECONE_DRESSER_CENTER_X = -24;
+const ROCKET_NOSECONE_FRAME_SIZE = 2.15 + 0.18 * 2 + 0.16 * 2;
+const ROCKET_NOSECONE_ANCHORED_X =
+  ROCKET_NOSECONE_DRESSER_CENTER_X - ROCKET_NOSECONE_FRAME_SIZE / 2;
 
 export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
   {
@@ -62,7 +66,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'ground',
     room: 'living room',
     wallOrientation: 'north',
-    position: { x: -24, y: 2.5, z: -30.06 },
+    position: { x: ROCKET_NOSECONE_ANCHORED_X, y: 2.5, z: -30.06 },
     size: 2.15,
     frame: {
       frameColor: 0x4f3528,

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -14,6 +14,8 @@ import {
 
 import { UPPER_FLOOR_TOP_ELEVATION } from '../level/floorElevations';
 
+import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from './lowerFloorFurnishings';
+
 export type WallPaintingFloor = 'ground' | 'upper';
 export type WallPaintingOrientation = 'north' | 'west';
 
@@ -53,10 +55,29 @@ export interface WallPaintingsBuild {
 const WALL_OFFSET = 0.08;
 const GROUND_PAINTING_CENTER_Y = 2.35;
 const UPPER_PAINTING_CENTER_Y = UPPER_FLOOR_TOP_ELEVATION + 2.2;
-const ROCKET_NOSECONE_DRESSER_CENTER_X = -24;
-const ROCKET_NOSECONE_FRAME_SIZE = 2.15 + 0.18 * 2 + 0.16 * 2;
-const ROCKET_NOSECONE_ANCHORED_X =
-  ROCKET_NOSECONE_DRESSER_CENTER_X - ROCKET_NOSECONE_FRAME_SIZE / 2;
+const ROCKET_NOSECONE_DRESSER_ID = 'living-room-south-bookcase-west';
+const ROCKET_NOSECONE_DRESSER_CENTER = getFurnishingCenter(
+  ROCKET_NOSECONE_DRESSER_ID
+);
+
+export function getFurnishingCenter(id: string): { x: number; z: number } {
+  const furnishing = DEFAULT_LOWER_FLOOR_FURNISHINGS.find(
+    (definition) => definition.id === id
+  );
+
+  if (!furnishing) {
+    throw new Error(`Missing lower-floor furnishing for wall painting: ${id}`);
+  }
+
+  if (furnishing.solidBounds) {
+    return {
+      x: (furnishing.solidBounds.minX + furnishing.solidBounds.maxX) / 2,
+      z: (furnishing.solidBounds.minZ + furnishing.solidBounds.maxZ) / 2,
+    };
+  }
+
+  return { x: furnishing.position.x, z: furnishing.position.z };
+}
 
 export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
   {
@@ -66,7 +87,11 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'ground',
     room: 'living room',
     wallOrientation: 'north',
-    position: { x: ROCKET_NOSECONE_ANCHORED_X, y: 2.5, z: -30.06 },
+    position: {
+      x: ROCKET_NOSECONE_DRESSER_CENTER.x,
+      y: 2.5,
+      z: ROCKET_NOSECONE_DRESSER_CENTER.z,
+    },
     size: 2.15,
     frame: {
       frameColor: 0x4f3528,


### PR DESCRIPTION
### Motivation
- Add six framed wall paintings to the immersive house so each provided 64×64 public image appears once and is visible from the isometric camera.  
- Keep placements camera-visible by mounting only on north or west walls and split the set across both floors (3 ground / 3 upper) to spread them through the house.  
- Implement a small, reusable, data-driven helper for ease of future placement tweaks and consistent disposal of textures/materials.

### Description
- Add `src/scene/structures/wallPaintings.ts` which declares a `WallPaintingConfig[]` (image path, floor/room, wall orientation, position, size, frame variant) and exports `createWallPaintings()` to build grouped painting meshes (ground and upper groups).  
- Each painting is a square image plane using `TextureLoader` with `colorSpace = SRGBColorSpace`, backed by a mat, backing plane, and a small 3D frame (varied frameThickness/frameDepth/frameColor/matBorder), and rails are built from shared box geometries/materials.  
- Wire the painting groups into the immersive scene in `src/main.ts` (import, create `wallPaintings`, add `groundGroup`/`upperGroup` to structure groups, and dispose during scene teardown).  
- Add a focused test `src/scene/structures/__tests__/wallPaintings.test.ts` that asserts exactly one painting per requested image, a 3/3 floor split, north/west-only orientation, and that frame variants are varied; no runtime deps were added.

### Testing
- Ran formatting and linting with `npm run format:write` and `npm run lint`, both completed (lint produced and then fixed an import-order warning).  
- Ran `npm run typecheck` and observed repo-wide TypeScript failures unrelated to these changes (pre-existing); this PR does not introduce new type issues in the painting helper itself.  
- Ran unit and CI tests with `npx vitest run src/scene/structures/__tests__/wallPaintings.test.ts` (new test) and `npm run test:ci`, and the test suite passed (`183` test files, all tests green).  
- Built and smoke-checked the app with `npm run build` and `npm run smoke` (both passed), ran `npm run docs:check` (passed with existing external-link warnings), scanned staged changes with `git diff --cached | ./scripts/scan-secrets.py` (no secrets), and verified the immersive preview via `npm run dev` plus a Playwright screenshot of `/?mode=immersive&disablePerformanceFailover=1` after installing Playwright browsers/dependencies, with no page errors captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45539890c4832fb8500026d83b71c0)