### PR TITLE
🖼️ : – Add framed wall paintings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -345,6 +345,10 @@ import {
   createUpperStairwellLanding,
   type UpperStairwellLandingCollider,
 } from './scene/structures/upperStairwellLanding';
+import {
+  createWallPaintings,
+  type WallPaintingsBuild,
+} from './scene/structures/wallPaintings';
 import { createWallSegmentMeshes } from './scene/structures/wallSegmentsMesh';
 import {
   createWoveLoom,
@@ -1107,6 +1111,7 @@ let gabrielSentry: GabrielSentryBuild | null = null;
 let gitshelvesInstallation: GitshelvesInstallationBuild | null = null;
 const mediaWallStarBridge = createMediaWallStarBridge();
 let livingRoomMediaWall: LivingRoomMediaWallBuild | null = null;
+let wallPaintings: WallPaintingsBuild | null = null;
 let futuroptimistTvModelRoot: Object3D | null = null;
 let selfieMirror: SelfieMirrorBuild | null = null;
 let ledStripGroup: Group | null = null;
@@ -2190,6 +2195,15 @@ function initializeImmersiveScene(
     groundColliders.push(mirror.collider);
     selfieMirror = mirror;
   }
+
+  wallPaintings = createWallPaintings();
+  [...wallPaintings.group.children].forEach((painting) => {
+    if (painting.userData.floor === 'upper') {
+      upperStructureGroup.add(painting);
+    } else {
+      groundStructureGroup.add(painting);
+    }
+  });
 
   const staircase = createStaircase(STAIRCASE_CONFIG);
   scene.add(staircase.group);
@@ -7069,6 +7083,10 @@ function initializeImmersiveScene(
     if (selfieMirror) {
       selfieMirror.dispose();
       selfieMirror = null;
+    }
+    if (wallPaintings) {
+      wallPaintings.dispose();
+      wallPaintings = null;
     }
     if (flywheelShowpiece) {
       flywheelShowpiece.dispose();

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -1,0 +1,337 @@
+import {
+  BoxGeometry,
+  Color,
+  Group,
+  Mesh,
+  MeshBasicMaterial,
+  MeshStandardMaterial,
+  NearestFilter,
+  PlaneGeometry,
+  SRGBColorSpace,
+  TextureLoader,
+  type ColorRepresentation,
+  type Material,
+  type Texture,
+} from 'three';
+
+export type WallPaintingFloorId = 'ground' | 'upper';
+export type WallPaintingOrientation = 'north' | 'west';
+
+export interface WallPaintingConfig {
+  id: string;
+  label: string;
+  imagePath: string;
+  floor: WallPaintingFloorId;
+  roomId: string;
+  wallOrientation: WallPaintingOrientation;
+  position: { x: number; y: number; z: number };
+  size: { width: number; height: number };
+  frameVariant: WallPaintingFrameVariant;
+}
+
+interface WallPaintingFrameVariant {
+  frameColor: ColorRepresentation;
+  matColor: ColorRepresentation;
+  thickness: number;
+  depth: number;
+  matBorder: number;
+  backingColor?: ColorRepresentation;
+}
+
+export interface WallPaintingsBuild {
+  group: Group;
+  dispose(): void;
+}
+
+export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
+  {
+    id: 'living-room-rocket-nosecone-painting',
+    label: '3D printed rocket nosecone',
+    imagePath: '/images/3dprinted_rocket_nosecone.jpg',
+    floor: 'ground',
+    roomId: 'livingRoom',
+    wallOrientation: 'north',
+    position: { x: -24.5, y: 1.58, z: -31.72 },
+    size: { width: 1.55, height: 1.55 },
+    frameVariant: {
+      frameColor: 0x4a3427,
+      matColor: 0xe8dcc8,
+      backingColor: 0x2d2520,
+      thickness: 0.16,
+      depth: 0.16,
+      matBorder: 0.13,
+    },
+  },
+  {
+    id: 'kitchen-3d-printer-painting',
+    label: '3D printer',
+    imagePath: '/images/3dprinter.jpg',
+    floor: 'ground',
+    roomId: 'kitchen',
+    wallOrientation: 'west',
+    position: { x: -31.72, y: 1.56, z: 8.0 },
+    size: { width: 1.35, height: 1.35 },
+    frameVariant: {
+      frameColor: 0xc29249,
+      matColor: 0x253247,
+      backingColor: 0x1c2432,
+      thickness: 0.12,
+      depth: 0.14,
+      matBorder: 0.1,
+    },
+  },
+  {
+    id: 'studio-democratized-space-painting',
+    label: 'Democratized Space',
+    imagePath: '/images/democratizedspace.jpg',
+    floor: 'ground',
+    roomId: 'studio',
+    wallOrientation: 'north',
+    position: { x: 24.0, y: 1.62, z: -7.72 },
+    size: { width: 1.45, height: 1.45 },
+    frameVariant: {
+      frameColor: 0x56616f,
+      matColor: 0xd8ccb8,
+      backingColor: 0x202833,
+      thickness: 0.14,
+      depth: 0.12,
+      matBorder: 0.16,
+    },
+  },
+  {
+    id: 'creators-studio-hydroponic-lamp-painting',
+    label: 'Hydroponic lamp',
+    imagePath: '/images/hydroponic_lamp.jpg',
+    floor: 'upper',
+    roomId: 'creatorsStudio',
+    wallOrientation: 'west',
+    position: { x: -19.72, y: 5.18, z: -25.0 },
+    size: { width: 1.28, height: 1.28 },
+    frameVariant: {
+      frameColor: 0x6e9b58,
+      matColor: 0x2b3648,
+      backingColor: 0x1f2a38,
+      thickness: 0.1,
+      depth: 0.13,
+      matBorder: 0.09,
+    },
+  },
+  {
+    id: 'loft-library-hypercar-painting',
+    label: 'Hypercar on grass',
+    imagePath: '/images/hypercar_grassy.jpg',
+    floor: 'upper',
+    roomId: 'loftLibrary',
+    wallOrientation: 'north',
+    position: { x: 20.6, y: 5.2, z: -15.72 },
+    size: { width: 1.62, height: 1.62 },
+    frameVariant: {
+      frameColor: 0x2f3740,
+      matColor: 0xe3d6bf,
+      backingColor: 0x1f2226,
+      thickness: 0.18,
+      depth: 0.18,
+      matBorder: 0.12,
+    },
+  },
+  {
+    id: 'focus-pods-launch-painting',
+    label: 'Launch',
+    imagePath: '/images/launch.jpg',
+    floor: 'upper',
+    roomId: 'focusPods',
+    wallOrientation: 'north',
+    position: { x: -12.0, y: 5.15, z: 12.28 },
+    size: { width: 1.5, height: 1.5 },
+    frameVariant: {
+      frameColor: 0x7d5f8a,
+      matColor: 0xf0e6d8,
+      backingColor: 0x2b2530,
+      thickness: 0.13,
+      depth: 0.15,
+      matBorder: 0.18,
+    },
+  },
+];
+
+const loader = new TextureLoader();
+
+export function createWallPaintings(
+  configs: readonly WallPaintingConfig[] = WALL_PAINTING_CONFIGS
+): WallPaintingsBuild {
+  const group = new Group();
+  group.name = 'WallPaintings';
+  const disposableTextures: Texture[] = [];
+  const disposableMaterials: Material[] = [];
+  const disposableGeometries: Array<BoxGeometry | PlaneGeometry> = [];
+
+  configs.forEach((config) => {
+    const texture = loader.load(config.imagePath);
+    texture.colorSpace = SRGBColorSpace;
+    texture.magFilter = NearestFilter;
+    texture.minFilter = NearestFilter;
+    disposableTextures.push(texture);
+
+    const painting = createPaintingMesh(config, texture, {
+      disposableMaterials,
+      disposableGeometries,
+    });
+    group.add(painting);
+  });
+
+  return {
+    group,
+    dispose() {
+      disposableTextures.forEach((texture) => texture.dispose());
+      disposableMaterials.forEach((material) => material.dispose());
+      disposableGeometries.forEach((geometry) => geometry.dispose());
+    },
+  };
+}
+
+function createPaintingMesh(
+  config: WallPaintingConfig,
+  texture: Texture,
+  disposables: {
+    disposableMaterials: Material[];
+    disposableGeometries: Array<BoxGeometry | PlaneGeometry>;
+  }
+): Group {
+  const { width, height } = config.size;
+  const { depth, matBorder, thickness } = config.frameVariant;
+  const fullWidth = width + matBorder * 2 + thickness * 2;
+  const fullHeight = height + matBorder * 2 + thickness * 2;
+  const painting = new Group();
+  painting.name = `WallPainting:${config.id}`;
+  painting.userData = {
+    floor: config.floor,
+    roomId: config.roomId,
+    wallOrientation: config.wallOrientation,
+    imagePath: config.imagePath,
+    label: config.label,
+  };
+  painting.position.set(
+    config.position.x,
+    config.position.y,
+    config.position.z
+  );
+  if (config.wallOrientation === 'west') {
+    painting.rotation.y = Math.PI / 2;
+  }
+
+  const frameMaterial = new MeshStandardMaterial({
+    color: config.frameVariant.frameColor,
+    roughness: 0.62,
+    metalness: 0.08,
+  });
+  const matMaterial = new MeshStandardMaterial({
+    color: new Color(config.frameVariant.matColor),
+    roughness: 0.86,
+    metalness: 0.02,
+  });
+  const backingMaterial = new MeshStandardMaterial({
+    color: config.frameVariant.backingColor ?? 0x273142,
+    roughness: 0.78,
+  });
+  const imageMaterial = new MeshBasicMaterial({
+    map: texture,
+    toneMapped: false,
+  });
+  disposables.disposableMaterials.push(
+    frameMaterial,
+    matMaterial,
+    backingMaterial,
+    imageMaterial
+  );
+
+  addPanel(
+    painting,
+    `${config.id}:backing`,
+    fullWidth,
+    fullHeight,
+    depth * 0.55,
+    backingMaterial,
+    [0, 0, -depth * 0.1],
+    disposables.disposableGeometries
+  );
+  addPanel(
+    painting,
+    `${config.id}:mat`,
+    width + matBorder * 2,
+    height + matBorder * 2,
+    depth * 0.28,
+    matMaterial,
+    [0, 0, depth * 0.12],
+    disposables.disposableGeometries
+  );
+
+  const railOffsetX = width / 2 + matBorder + thickness / 2;
+  const railOffsetY = height / 2 + matBorder + thickness / 2;
+  addPanel(
+    painting,
+    `${config.id}:frameLeft`,
+    thickness,
+    fullHeight,
+    depth,
+    frameMaterial,
+    [-railOffsetX, 0, depth * 0.2],
+    disposables.disposableGeometries
+  );
+  addPanel(
+    painting,
+    `${config.id}:frameRight`,
+    thickness,
+    fullHeight,
+    depth,
+    frameMaterial,
+    [railOffsetX, 0, depth * 0.2],
+    disposables.disposableGeometries
+  );
+  addPanel(
+    painting,
+    `${config.id}:frameTop`,
+    fullWidth,
+    thickness,
+    depth,
+    frameMaterial,
+    [0, railOffsetY, depth * 0.2],
+    disposables.disposableGeometries
+  );
+  addPanel(
+    painting,
+    `${config.id}:frameBottom`,
+    fullWidth,
+    thickness,
+    depth,
+    frameMaterial,
+    [0, -railOffsetY, depth * 0.2],
+    disposables.disposableGeometries
+  );
+
+  const imageGeometry = new PlaneGeometry(width, height);
+  const image = new Mesh(imageGeometry, imageMaterial);
+  image.name = `WallPainting:${config.id}:image`;
+  image.position.z = depth * 0.72;
+  painting.add(image);
+  disposables.disposableGeometries.push(imageGeometry);
+
+  return painting;
+}
+
+function addPanel(
+  group: Group,
+  name: string,
+  width: number,
+  height: number,
+  depth: number,
+  material: MeshStandardMaterial,
+  position: [number, number, number],
+  disposableGeometries: Array<BoxGeometry | PlaneGeometry>
+): void {
+  const geometry = new BoxGeometry(width, height, depth);
+  const mesh = new Mesh(geometry, material);
+  mesh.name = name;
+  mesh.position.set(...position);
+  group.add(mesh);
+  disposableGeometries.push(geometry);
+}

--- a/src/tests/wallPaintings.test.ts
+++ b/src/tests/wallPaintings.test.ts
@@ -1,0 +1,66 @@
+import { Mesh, MeshBasicMaterial, SRGBColorSpace } from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  WALL_PAINTING_CONFIGS,
+  createWallPaintings,
+} from '../scene/structures/wallPaintings';
+
+const EXPECTED_IMAGE_PATHS = [
+  '/images/3dprinted_rocket_nosecone.jpg',
+  '/images/3dprinter.jpg',
+  '/images/democratizedspace.jpg',
+  '/images/hydroponic_lamp.jpg',
+  '/images/hypercar_grassy.jpg',
+  '/images/launch.jpg',
+];
+
+describe('wall paintings', () => {
+  it('places exactly one configured painting for each public image asset', () => {
+    expect(WALL_PAINTING_CONFIGS).toHaveLength(6);
+    expect(
+      WALL_PAINTING_CONFIGS.map(({ imagePath }) => imagePath).sort()
+    ).toEqual([...EXPECTED_IMAGE_PATHS].sort());
+  });
+
+  it('splits visible wall paintings across north and west walls on both floors', () => {
+    expect(
+      WALL_PAINTING_CONFIGS.filter(({ floor }) => floor === 'ground')
+    ).toHaveLength(3);
+    expect(
+      WALL_PAINTING_CONFIGS.filter(({ floor }) => floor === 'upper')
+    ).toHaveLength(3);
+    expect(
+      WALL_PAINTING_CONFIGS.every(({ wallOrientation }) =>
+        ['north', 'west'].includes(wallOrientation)
+      )
+    ).toBe(true);
+    expect(
+      new Set(WALL_PAINTING_CONFIGS.map(({ roomId }) => roomId)).size
+    ).toBe(6);
+  });
+
+  it('builds framed image planes with SRGB textures and floor metadata', () => {
+    const build = createWallPaintings();
+    expect(build.group.children).toHaveLength(6);
+    build.group.children.forEach((painting) => {
+      expect(painting.name).toMatch(/^WallPainting:/);
+      expect(['ground', 'upper']).toContain(painting.userData.floor);
+      expect(['north', 'west']).toContain(painting.userData.wallOrientation);
+      const image = painting.children.find((child) =>
+        child.name.endsWith(':image')
+      );
+      expect(image).toBeInstanceOf(Mesh);
+      const material = (image as Mesh).material;
+      expect(Array.isArray(material)).toBe(false);
+      if (!Array.isArray(material)) {
+        expect(material).toBeInstanceOf(MeshBasicMaterial);
+        expect((material as MeshBasicMaterial).map?.colorSpace).toBe(
+          SRGBColorSpace
+        );
+      }
+      expect(painting.children.length).toBeGreaterThanOrEqual(6);
+    });
+    build.dispose();
+  });
+});


### PR DESCRIPTION
### Motivation
- Add six framed wall paintings using the provided 64×64 public images so the immersive house has visible, camera-friendly art. 
- Keep placements visible from the canonical isometric camera by mounting only on north- or west-facing walls and distributing three paintings per floor. 
- Implement a small, reusable, data-driven solution that respects existing furnishing/collider policies and disposal patterns.

### Description
- Introduced a data-driven `WALL_PAINTING_CONFIGS: WallPaintingConfig[]` describing image path, floor/room, wall orientation, world position, size, and a `frameVariant` for per-painting visual variety in `src/scene/structures/wallPaintings.ts`.
- Built a reusable `createWallPaintings()` helper that creates framed image meshes with SRGB `Texture` maps, `NearestFilter` sampling for crisp 64×64 visuals, subtle mat/backing, and frame depth; shared geometries/materials are tracked and disposed in a `dispose()` method.
- Wired the paintings into the scene composition in `src/main.ts` so each painting is added to either the ground or upper floor structure groups and disposed during immersive teardown.
- Added a Vitest file `src/tests/wallPaintings.test.ts` that asserts exactly six configured paintings, correct image paths, floor split (3/3), allowed orientations, unique room spread, and that built image materials use SRGB textures.

### Testing
- Ran formatting with `npm run format:write` which completed successfully.
- Ran lint with `npm run lint` which completed (one import-order warning was fixed during the change).
- Ran unit tests with `npm run test:ci` which passed (the repository test suite ran and the new `wallPaintings` tests passed along with existing tests).
- Verified production build and smoke checks with `npm run build` and `npm run smoke`, both of which completed successfully.
- Per acceptance verification, launched the dev server with `npm run dev` and captured an immersive preview screenshot using Playwright at `http://127.0.0.1:5173/?mode=immersive&disablePerformanceFailover=1`, confirming the immersive canvas rendered and paintings are visible.
- Type checking with `npm run typecheck` currently fails due to pre-existing TypeScript baseline issues unrelated to this change and not introduced by the wall paintings; those failures were reported but no new type errors come from the added files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45538ec13c832fb73d9c30f33a7901)