### PR TITLE
🖼️ : – Address immersive wall painting review feedback

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -446,6 +446,16 @@
       "metadataFingerprint": "7009d9e03ef23dc72075bcf9994511fdf918a8f11751b29f8903c1ca2a4e107b"
     },
     {
+      "id": "decor:wall-paintings",
+      "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
+      "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
+      "syncRevision": 1,
+      "syncNote": "Wall paintings are represented by simplified framed planes for tabletop readability.",
+      "sourceFingerprint": "27579a08ac6a1f674d43966e7eb79f79fbb1b7af04092187eb30ae2d4dc59fb6",
+      "proxyFingerprint": "d54aaff1e3eba627fc089a3203da1f15d8a80a04429952b03acc2eac567afa82",
+      "metadataFingerprint": "c7f297e6b65e1fccdc31b1688aa988d248097029cf2d7144d805ae4f8667eb70"
+    },
+    {
       "id": "environment:backyard",
       "sourceFiles": ["src/scene/environments/backyard.ts"],
       "proxyFiles": [],

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -454,6 +454,15 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
       'Multiplayer projection visible screen and plinth are represented by simplified proxy geometry.',
   },
   {
+    id: 'decor:wall-paintings',
+    kind: 'proxy',
+    sourceFiles: ['src/scene/structures/wallPaintings.ts'],
+    proxyFiles: [SELF_FILE],
+    syncRevision: 1,
+    syncNote:
+      'Wall paintings are represented by simplified framed planes for tabletop readability.',
+  },
+  {
     id: 'audit:src:scene:structures:triangleCount',
     kind: 'excluded',
     sourceFiles: ['src/scene/structures/triangleCount.ts'],
@@ -544,6 +553,30 @@ export const MINIATURE_SCENE_COMPONENT_PROXIES: readonly MiniatureProxyDefinitio
           radius: 0.16,
           position: [0, 0.75, 0],
           color: 0xfef08a,
+        },
+      ],
+    },
+    {
+      id: 'component:wall-paintings',
+      displayName: 'Wall paintings proxy',
+      syncRevision: 1,
+      syncNote: 'Simplified framed wall art planes.',
+      sourceFiles: ['src/scene/structures/wallPaintings.ts'],
+      proxyFiles: [SELF_FILE],
+      primitives: [
+        {
+          kind: 'plane',
+          name: 'miniature-wall-painting-image',
+          size: [0.52, 0, 0.52],
+          position: [0, 0.55, 0],
+          color: 0xf8fafc,
+        },
+        {
+          kind: 'box',
+          name: 'miniature-wall-painting-frame',
+          size: [0.62, 0.04, 0.62],
+          position: [0, 0.55, -0.02],
+          color: 0x6d4c2f,
         },
       ],
     },

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -51,7 +51,7 @@ describe('WALL_PAINTING_CONFIGS', () => {
       )
     );
 
-    expect(variants.size).toBe(WALL_PAINTING_CONFIGS.length);
+    expect(variants.size).toBeGreaterThan(1);
     expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
   });
 });

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -26,6 +26,8 @@ export interface WallPaintingFrameVariant {
   readonly backingDepth?: number;
 }
 
+export type WallPaintingMountSide = 'positive' | 'negative';
+
 export interface WallPaintingConfig {
   readonly id: string;
   readonly label: string;
@@ -33,13 +35,13 @@ export interface WallPaintingConfig {
   readonly floor: WallPaintingFloor;
   readonly room: string;
   readonly wallOrientation: WallPaintingOrientation;
+  readonly mountSide?: WallPaintingMountSide;
   readonly position: { readonly x: number; readonly z: number };
   readonly size: number;
   readonly frame: WallPaintingFrameVariant;
 }
 
 export interface WallPaintingsBuild {
-  readonly group: Group;
   readonly groundGroup: Group;
   readonly upperGroup: Group;
   readonly configs: readonly WallPaintingConfig[];
@@ -144,6 +146,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'upper',
     room: 'focus pods',
     wallOrientation: 'north',
+    mountSide: 'negative',
     position: { x: -3.8, z: 27.92 },
     size: 2.1,
     frame: {
@@ -160,13 +163,10 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
 export function createWallPaintings(
   configs: readonly WallPaintingConfig[] = WALL_PAINTING_CONFIGS
 ): WallPaintingsBuild {
-  const group = new Group();
-  group.name = 'WallPaintings';
   const groundGroup = new Group();
   groundGroup.name = 'GroundWallPaintings';
   const upperGroup = new Group();
   upperGroup.name = 'UpperWallPaintings';
-  group.add(groundGroup, upperGroup);
 
   const textureLoader = new TextureLoader();
   const textures: Texture[] = [];
@@ -186,7 +186,6 @@ export function createWallPaintings(
   });
 
   return {
-    group,
     groundGroup,
     upperGroup,
     configs,
@@ -264,7 +263,7 @@ function createWallPainting(
     frameMaterial,
     geometries
   );
-  placeOnWall(group, config);
+  placeOnWall(group, config, backingDepth);
 
   return group;
 }
@@ -299,26 +298,32 @@ function addFrameRails(
   });
 }
 
-function placeOnWall(group: Group, config: WallPaintingConfig): void {
+function placeOnWall(
+  group: Group,
+  config: WallPaintingConfig,
+  backingDepth: number
+): void {
   const centerY =
     config.floor === 'upper'
       ? UPPER_PAINTING_CENTER_Y
       : GROUND_PAINTING_CENTER_Y;
-  const wallOffset = WALL_OFFSET + config.frame.frameDepth / 2;
+  const wallOffset = WALL_OFFSET + backingDepth / 2;
+  const mountSign = config.mountSide === 'negative' ? -1 : 1;
 
   if (config.wallOrientation === 'west') {
     group.position.set(
-      config.position.x + wallOffset,
+      config.position.x + wallOffset * mountSign,
       centerY,
       config.position.z
     );
-    group.rotation.y = Math.PI / 2;
+    group.rotation.y = mountSign > 0 ? Math.PI / 2 : -Math.PI / 2;
     return;
   }
 
   group.position.set(
     config.position.x,
     centerY,
-    config.position.z + wallOffset
+    config.position.z + wallOffset * mountSign
   );
+  group.rotation.y = mountSign > 0 ? 0 : Math.PI;
 }


### PR DESCRIPTION
### Motivation
- Ensure north-wall paintings can be mounted on the room-facing side and that mount/rotation is configurable for edge cases.  
- Prevent a misleading public API surface by removing an orphaned top-level group that never contains children after callers reparent floor groups.  
- Make wall placement physically correct by computing mount offsets from the backing geometry that contacts the wall.  
- Keep unit tests meaningful and add tabletop/minature proxy coverage for audit tooling.

### Description
- Add a `mountSide` option (`'positive' | 'negative'`) to `WallPaintingConfig` and use it in `placeOnWall(...)` to flip offset sign and rotation for room-facing mounts in `src/scene/structures/wallPaintings.ts`.  
- Compute wall offset using the painting `backingDepth` (not `frameDepth`) so mount distance matches the actual contacting geometry.  
- Remove the orphan top-level `group` from the `WallPaintingsBuild` API and return only `groundGroup` and `upperGroup` so callers should attach those floor groups directly to the scene.  
- Relax the frame-variant unit test to assert that frame treatments vary (`expect(...).toBeGreaterThan(1)`) instead of requiring every painting to be uniquely variant, and set `mountSide: 'negative'` for the `hypercar-focus-pods-north` config.  
- Add tabletop/minature proxy entries for the new `wallPaintings.ts` source in `src/scene/miniature/sceneComponentRegistry.ts` and refresh `src/scene/miniature/miniatureManifest.generated.json` with `npm run miniature:manifest:update` so the miniature manifest audit passes.

### Testing
- Ran formatting with `npm run format:write`, and lint with `npm run lint`, both completed successfully.  
- Ran the full test suite `npm run test:ci` (Vitest) and all test files passed (`183` test files, all tests green).  
- Updated and validated the miniature manifest with `npm run miniature:manifest:update` so `scripts/miniatureManifest.ts` audit no longer reports the new source as unaudited.  
- Ran `npm run docs:check` (passed with existing external-link warnings) and `npm run smoke` / `npm run build` (smoke check passed).  
- Ran `git diff --cached | ./scripts/scan-secrets.py` and it reported no high-risk secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a455a2b1860832fbec280730e2f928f)