### PR TITLE
🖼️ Fix 3D-printer wall painting mount

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -451,8 +451,8 @@
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
       "syncRevision": 8,
       "syncNote": "Wall-painting API cleanup keeps the same representative tabletop proxy geometry.",
-      "sourceFingerprint": "06ac3d14e53d098f7583918a19563c1b78166069f540e232ba8ab73d4667c3f8",
-      "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
+      "sourceFingerprint": "08c0cba49ef9f79dcb743cdc262ce0b166131ff1d26384a96b85acd91e40cda7",
+      "proxyFingerprint": "3af7b16342950ad47633e0f5e8753ecc011577514fb1240e861aa276e4c67449",
       "metadataFingerprint": "2bcc02f8f0a71e3f95f9bdda15b0cf21f9cb1ef8f24ace7bf5b08566db87dde7"
     },
     {

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -511,8 +511,9 @@ export const MINIATURE_SCENE_COMPONENT_PROXIES: readonly MiniatureProxyDefinitio
     {
       id: 'component:wall-paintings',
       displayName: 'Wall painting proxy',
-      syncRevision: 1,
-      syncNote: 'Simplified framed wall paintings.',
+      syncRevision: 2,
+      syncNote:
+        'Acknowledges wall painting mount-side metadata; proxy unchanged.',
       sourceFiles: ['src/scene/structures/wallPaintings.ts'],
       proxyFiles: [SELF_FILE],
       primitives: [

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { Euler, Mesh, Texture, TextureLoader, Vector3 } from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from '../lowerFloorFurnishings';
-import { WALL_PAINTING_CONFIGS, getFurnishingCenter } from '../wallPaintings';
+import {
+  WALL_PAINTING_CONFIGS,
+  createWallPaintings,
+  getFurnishingCenter,
+  resolveWallPaintingMountPose,
+} from '../wallPaintings';
 
 const EXPECTED_IMAGE_PATHS = [
   '/images/3dprinted_rocket_nosecone.jpg',
@@ -12,7 +18,21 @@ const EXPECTED_IMAGE_PATHS = [
   '/images/launch.jpg',
 ] as const;
 
+const EXPECTED_PART_SUFFIXES = [
+  'backing',
+  'mat',
+  'image',
+  'left-rail',
+  'right-rail',
+  'top-rail',
+  'bottom-rail',
+] as const;
+
 describe('WALL_PAINTING_CONFIGS', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('places exactly one painting for each public image asset', () => {
     expect(WALL_PAINTING_CONFIGS).toHaveLength(EXPECTED_IMAGE_PATHS.length);
     expect(
@@ -70,5 +90,116 @@ describe('WALL_PAINTING_CONFIGS', () => {
 
     expect(variants.size).toBeGreaterThan(1);
     expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
+  });
+
+  it('resolves every painting to an outward-facing north or west wall mount', () => {
+    WALL_PAINTING_CONFIGS.forEach((config) => {
+      const pose = resolveWallPaintingMountPose(config);
+      const normalLength = new Vector3(
+        pose.outwardNormal.x,
+        pose.outwardNormal.y,
+        pose.outwardNormal.z
+      ).length();
+
+      expect(['x', 'z']).toContain(pose.wallAxis);
+      expect(normalLength).toBeCloseTo(1);
+
+      if (config.wallOrientation === 'west') {
+        expect(pose.wallAxis).toBe('x');
+        expect(pose.position.z).toBe(config.position.z);
+        expect(pose.outwardNormal.x).toBe(pose.offsetDirection);
+        expect(pose.outwardNormal.z).toBe(0);
+        if (config.wallSide === 'negative') {
+          expect(pose.position.x).toBeLessThan(config.position.x);
+        } else {
+          expect(pose.position.x).toBeGreaterThan(config.position.x);
+        }
+      } else {
+        expect(pose.wallAxis).toBe('z');
+        expect(pose.position.x).toBe(config.position.x);
+        expect(pose.outwardNormal.x).toBe(0);
+        expect(pose.outwardNormal.z).toBe(pose.offsetDirection);
+        if (config.wallSide === 'negative') {
+          expect(pose.position.z).toBeLessThan(config.position.z);
+        } else {
+          expect(pose.position.z).toBeGreaterThan(config.position.z);
+        }
+      }
+    });
+  });
+
+  it('builds each painting with visible image, mat, backing, and four frame rails', () => {
+    vi.spyOn(TextureLoader.prototype, 'load').mockImplementation((path) => {
+      const texture = new Texture();
+      texture.name = `MockTexture:${path}`;
+      return texture;
+    });
+
+    const wallPaintings = createWallPaintings();
+    const paintings = [
+      ...wallPaintings.groundGroup.children,
+      ...wallPaintings.upperGroup.children,
+    ];
+
+    try {
+      expect(paintings).toHaveLength(WALL_PAINTING_CONFIGS.length);
+
+      WALL_PAINTING_CONFIGS.forEach((config) => {
+        const group = paintings.find(
+          (painting) => painting.name === `WallPainting:${config.id}`
+        );
+        const pose = resolveWallPaintingMountPose(config);
+
+        expect(group).toBeDefined();
+        expect(group!.position.x).toBeCloseTo(pose.position.x);
+        expect(group!.position.y).toBeCloseTo(pose.position.y);
+        expect(group!.position.z).toBeCloseTo(pose.position.z);
+        expect(group!.rotation.y).toBeCloseTo(pose.rotationY);
+
+        EXPECTED_PART_SUFFIXES.forEach((suffix) => {
+          expect(
+            group!.getObjectByName(`WallPainting:${config.id}:${suffix}`)
+          ).toBeDefined();
+        });
+
+        const image = group!.getObjectByName(
+          `WallPainting:${config.id}:image`
+        ) as Mesh;
+        const mat = group!.getObjectByName(
+          `WallPainting:${config.id}:mat`
+        ) as Mesh;
+        const backing = group!.getObjectByName(
+          `WallPainting:${config.id}:backing`
+        ) as Mesh;
+        const imageNormal = new Vector3(0, 0, 1).applyEuler(
+          new Euler(0, group!.rotation.y, 0)
+        );
+
+        expect(image.position.z).toBeGreaterThan(mat.position.z);
+        expect(mat.position.z).toBeGreaterThan(backing.position.z);
+        expect(imageNormal.x).toBeCloseTo(pose.outwardNormal.x);
+        expect(imageNormal.y).toBeCloseTo(pose.outwardNormal.y);
+        expect(imageNormal.z).toBeCloseTo(pose.outwardNormal.z);
+      });
+    } finally {
+      wallPaintings.dispose();
+    }
+  });
+
+  it('mounts the 3D printer image on the negative-X side of the interior west wall', () => {
+    const printerPainting = WALL_PAINTING_CONFIGS.find(
+      (config) => config.id === '3d-printer-loft-library-west'
+    );
+
+    expect(printerPainting).toBeDefined();
+
+    const pose = resolveWallPaintingMountPose(printerPainting!);
+
+    expect(printerPainting!.wallOrientation).toBe('west');
+    expect(printerPainting!.wallSide).toBe('negative');
+    expect(pose.wallAxis).toBe('x');
+    expect(pose.position.x).toBeLessThan(printerPainting!.position.x);
+    expect(pose.outwardNormal).toEqual({ x: -1, y: 0, z: 0 });
+    expect(pose.rotationY).toBeCloseTo(-Math.PI / 2);
   });
 });

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -18,6 +18,8 @@ import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from './lowerFloorFurnishings';
 
 export type WallPaintingFloor = 'ground' | 'upper';
 export type WallPaintingOrientation = 'north' | 'west';
+export type WallPaintingSurfaceSide = 'positive' | 'negative';
+export type WallPaintingWallAxis = 'x' | 'z';
 
 export interface WallPaintingFrameVariant {
   readonly frameColor: ColorRepresentation;
@@ -35,6 +37,7 @@ export interface WallPaintingConfig {
   readonly floor: WallPaintingFloor;
   readonly room: string;
   readonly wallOrientation: WallPaintingOrientation;
+  readonly wallSide?: WallPaintingSurfaceSide;
   readonly position: {
     readonly x: number;
     // Optional additive offset from the floor's default painting center height.
@@ -43,6 +46,22 @@ export interface WallPaintingConfig {
   };
   readonly size: number;
   readonly frame: WallPaintingFrameVariant;
+}
+
+export interface WallPaintingMountPose {
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly rotationY: number;
+  readonly wallAxis: WallPaintingWallAxis;
+  readonly outwardNormal: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly offsetDirection: 1 | -1;
 }
 
 export interface WallPaintingsBuild {
@@ -161,6 +180,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'upper',
     room: 'loft library',
     wallOrientation: 'west',
+    wallSide: 'negative',
     position: { x: 4.08, z: -3.2 },
     size: 1.9,
     frame: {
@@ -329,7 +349,9 @@ function addFrameRails(
   });
 }
 
-function placeOnWall(group: Group, config: WallPaintingConfig): void {
+export function resolveWallPaintingMountPose(
+  config: WallPaintingConfig
+): WallPaintingMountPose {
   const baseCenterY =
     config.floor === 'upper'
       ? UPPER_PAINTING_CENTER_Y
@@ -337,20 +359,38 @@ function placeOnWall(group: Group, config: WallPaintingConfig): void {
   const centerY = baseCenterY + (config.position.y ?? 0);
   const backingDepth = config.frame.backingDepth ?? DEFAULT_BACKING_DEPTH;
   const wallOffset = WALL_OFFSET + backingDepth / 2;
+  const offsetDirection = config.wallSide === 'negative' ? -1 : 1;
 
   if (config.wallOrientation === 'west') {
-    group.position.set(
-      config.position.x + wallOffset,
-      centerY,
-      config.position.z
-    );
-    group.rotation.y = Math.PI / 2;
-    return;
+    return {
+      position: {
+        x: config.position.x + wallOffset * offsetDirection,
+        y: centerY,
+        z: config.position.z,
+      },
+      rotationY: (Math.PI / 2) * offsetDirection,
+      wallAxis: 'x',
+      outwardNormal: { x: offsetDirection, y: 0, z: 0 },
+      offsetDirection,
+    };
   }
 
-  group.position.set(
-    config.position.x,
-    centerY,
-    config.position.z + wallOffset
-  );
+  return {
+    position: {
+      x: config.position.x,
+      y: centerY,
+      z: config.position.z + wallOffset * offsetDirection,
+    },
+    rotationY: offsetDirection === 1 ? 0 : Math.PI,
+    wallAxis: 'z',
+    outwardNormal: { x: 0, y: 0, z: offsetDirection },
+    offsetDirection,
+  };
+}
+
+function placeOnWall(group: Group, config: WallPaintingConfig): void {
+  const pose = resolveWallPaintingMountPose(config);
+
+  group.position.set(pose.position.x, pose.position.y, pose.position.z);
+  group.rotation.y = pose.rotationY;
 }


### PR DESCRIPTION
### Motivation
- The upstairs `3d-printer-loft-library-west` painting rendered as an empty/dark frame because the image and mat use single-sided planes and were mounted facing the wall/back side. 
- Add a small data-driven mount-side concept so paintings on interior walls can be mounted on the camera-visible side without using `DoubleSide` materials.

### Description
- Added optional `wallSide?: 'positive' | 'negative'` to `WallPaintingConfig` and supporting types so mount side can be expressed per painting. 
- Introduced a pure helper `resolveWallPaintingMountPose(config)` that returns resolved position, `rotationY`, `wallAxis`, `outwardNormal`, and `offsetDirection` for tests and placement. 
- Kept existing default behavior and set only `3d-printer-loft-library-west` to `wallSide: 'negative'` so its image plane faces negative-X (interior visible side) while other paintings remain unchanged. 
- Added regression tests in `src/scene/structures/__tests__/wallPaintings.test.ts` to verify resolved mount poses, outward normals, presence of backing/mat/image/frame rails, and the specific 3D-printer negative-X orientation, and refreshed miniature metadata to acknowledge the change.

### Testing
- Ran formatting with `npm run format:write` which completed successfully. 
- Ran lint with `npm run lint` which completed successfully. 
- Ran unit tests with `npm run test:ci` and all tests passed (`183 files, 1469 tests` reported in the run). 
- Ran docs check with `npm run docs:check` which passed but emitted existing external link fetch warnings. 
- Built and smoke-checked the app with `npm run build` and `npm run smoke`, both of which completed successfully. 
- Updated miniature manifest with `npm run miniature:manifest:update` and validated with `npm run miniature:check`, both completed successfully. 
- Attempted TypeScript check with `npm run typecheck` which failed due to pre-existing, repository-wide TypeScript errors unrelated to this change. 
- Attempted an automated visual capture via Playwright to validate the rendered scene but the environment lacked Playwright browser binaries so the capture did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fbdf27dc832fb1b72db608f9515e)