### PR TITLE
Fix 3D-printer wall painting mount side

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 8,
-      "syncNote": "Wall-painting API cleanup keeps the same representative tabletop proxy geometry.",
-      "sourceFingerprint": "06ac3d14e53d098f7583918a19563c1b78166069f540e232ba8ab73d4667c3f8",
-      "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "2bcc02f8f0a71e3f95f9bdda15b0cf21f9cb1ef8f24ace7bf5b08566db87dde7"
+      "syncRevision": 9,
+      "syncNote": "Wall-painting mount-side fix keeps the same representative tabletop proxy geometry.",
+      "sourceFingerprint": "94a0d8bf79433d1ef6c7b929fdf0d4c876ef095e7e0a2123160703ccd04a9e06",
+      "proxyFingerprint": "a0d5a6e253b49370071add935b7f0b7f1589eaa8b40a01454d0704a9cf1c9aea",
+      "metadataFingerprint": "c04d4343060f5893137be01bb6846e8fc53ce6bd68d08c68ce451636dcf095d4"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 8,
+    syncRevision: 9,
     syncNote:
-      'Wall-painting API cleanup keeps the same representative tabletop proxy geometry.',
+      'Wall-painting mount-side fix keeps the same representative tabletop proxy geometry.',
   },
   {
     id: 'decor:lower-floor-furnishings',
@@ -511,8 +511,9 @@ export const MINIATURE_SCENE_COMPONENT_PROXIES: readonly MiniatureProxyDefinitio
     {
       id: 'component:wall-paintings',
       displayName: 'Wall painting proxy',
-      syncRevision: 1,
-      syncNote: 'Simplified framed wall paintings.',
+      syncRevision: 2,
+      syncNote:
+        'Simplified framed wall paintings; mount-side changes do not alter tabletop proxy geometry.',
       sourceFiles: ['src/scene/structures/wallPaintings.ts'],
       proxyFiles: [SELF_FILE],
       primitives: [

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it } from 'vitest';
+import {
+  BoxGeometry,
+  Mesh,
+  PlaneGeometry,
+  Texture,
+  TextureLoader,
+  Vector3,
+} from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from '../lowerFloorFurnishings';
-import { WALL_PAINTING_CONFIGS, getFurnishingCenter } from '../wallPaintings';
+import {
+  WALL_PAINTING_CONFIGS,
+  createWallPaintings,
+  getFurnishingCenter,
+  resolveWallPaintingMountPose,
+} from '../wallPaintings';
 
 const EXPECTED_IMAGE_PATHS = [
   '/images/3dprinted_rocket_nosecone.jpg',
@@ -13,6 +26,10 @@ const EXPECTED_IMAGE_PATHS = [
 ] as const;
 
 describe('WALL_PAINTING_CONFIGS', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('places exactly one painting for each public image asset', () => {
     expect(WALL_PAINTING_CONFIGS).toHaveLength(EXPECTED_IMAGE_PATHS.length);
     expect(
@@ -70,5 +87,123 @@ describe('WALL_PAINTING_CONFIGS', () => {
 
     expect(variants.size).toBeGreaterThan(1);
     expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
+  });
+
+  it('resolves each painting to a wall-mounted pose on the allowed axes', () => {
+    WALL_PAINTING_CONFIGS.forEach((config) => {
+      const pose = resolveWallPaintingMountPose(config);
+      const normal = new Vector3(
+        pose.outwardNormal.x,
+        pose.outwardNormal.y,
+        pose.outwardNormal.z
+      );
+
+      expect(['x', 'z']).toContain(pose.wallAxis);
+      expect(normal.length()).toBeCloseTo(1);
+
+      if (config.wallOrientation === 'west') {
+        expect(pose.wallAxis).toBe('x');
+        expect(Math.abs(pose.outwardNormal.x)).toBe(1);
+        expect(pose.outwardNormal.z).toBe(0);
+        expect(Math.sign(pose.position.x - config.position.x)).toBe(
+          Math.sign(pose.outwardNormal.x)
+        );
+      } else {
+        expect(pose.wallAxis).toBe('z');
+        expect(Math.abs(pose.outwardNormal.z)).toBe(1);
+        expect(pose.outwardNormal.x).toBe(0);
+        expect(Math.sign(pose.position.z - config.position.z)).toBe(
+          Math.sign(pose.outwardNormal.z)
+        );
+      }
+    });
+  });
+
+  it('mounts the 3D-printer painting on the west side of the interior wall', () => {
+    const config = WALL_PAINTING_CONFIGS.find(
+      (entry) => entry.id === '3d-printer-loft-library-west'
+    );
+
+    expect(config).toBeDefined();
+
+    const pose = resolveWallPaintingMountPose(config!);
+    expect(config!.surfaceSide).toBe('negative');
+    expect(pose.wallAxis).toBe('x');
+    expect(pose.outwardNormal).toMatchObject({ x: -1, y: 0, z: 0 });
+    expect(pose.position.x).toBeLessThan(config!.position.x);
+    expect(pose.rotation.y).toBeCloseTo(-Math.PI / 2);
+  });
+
+  it('builds visible painting parts with image planes in front of the backing', () => {
+    vi.spyOn(TextureLoader.prototype, 'load').mockImplementation(
+      () => new Texture()
+    );
+
+    const build = createWallPaintings();
+    const paintings = [
+      ...build.groundGroup.children,
+      ...build.upperGroup.children,
+    ];
+
+    expect(paintings).toHaveLength(WALL_PAINTING_CONFIGS.length);
+
+    paintings.forEach((painting) => {
+      const config = WALL_PAINTING_CONFIGS.find(
+        (entry) => painting.name === `WallPainting:${entry.id}`
+      );
+      expect(config).toBeDefined();
+
+      const expectedParts = [
+        'backing',
+        'mat',
+        'image',
+        'left-rail',
+        'right-rail',
+        'top-rail',
+        'bottom-rail',
+      ];
+      const childrenByPart = new Map(
+        painting.children.map((child) => [child.name.split(':').at(-1), child])
+      );
+
+      expectedParts.forEach((part) =>
+        expect(childrenByPart.has(part)).toBe(true)
+      );
+      expect(painting.children).toHaveLength(expectedParts.length);
+
+      expect(childrenByPart.get('backing')).toBeInstanceOf(Mesh);
+      expect((childrenByPart.get('backing') as Mesh).geometry).toBeInstanceOf(
+        BoxGeometry
+      );
+      expect((childrenByPart.get('mat') as Mesh).geometry).toBeInstanceOf(
+        PlaneGeometry
+      );
+      expect((childrenByPart.get('image') as Mesh).geometry).toBeInstanceOf(
+        PlaneGeometry
+      );
+
+      const pose = resolveWallPaintingMountPose(config!);
+      const normal = new Vector3(
+        pose.outwardNormal.x,
+        pose.outwardNormal.y,
+        pose.outwardNormal.z
+      );
+      const image = childrenByPart.get('image')!;
+      const backing = childrenByPart.get('backing')!;
+
+      painting.updateWorldMatrix(true, true);
+      const imageWorldPosition = image.getWorldPosition(new Vector3());
+      const backingWorldPosition = backing.getWorldPosition(new Vector3());
+      const imageNormal = new Vector3(0, 0, 1)
+        .applyQuaternion(image.getWorldQuaternion(image.quaternion.clone()))
+        .normalize();
+
+      expect(imageNormal.dot(normal)).toBeCloseTo(1);
+      expect(
+        imageWorldPosition.sub(backingWorldPosition).dot(normal)
+      ).toBeGreaterThan(0);
+    });
+
+    build.dispose();
   });
 });

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -18,6 +18,7 @@ import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from './lowerFloorFurnishings';
 
 export type WallPaintingFloor = 'ground' | 'upper';
 export type WallPaintingOrientation = 'north' | 'west';
+export type WallPaintingSurfaceSide = 'positive' | 'negative';
 
 export interface WallPaintingFrameVariant {
   readonly frameColor: ColorRepresentation;
@@ -35,6 +36,7 @@ export interface WallPaintingConfig {
   readonly floor: WallPaintingFloor;
   readonly room: string;
   readonly wallOrientation: WallPaintingOrientation;
+  readonly surfaceSide?: WallPaintingSurfaceSide;
   readonly position: {
     readonly x: number;
     // Optional additive offset from the floor's default painting center height.
@@ -43,6 +45,26 @@ export interface WallPaintingConfig {
   };
   readonly size: number;
   readonly frame: WallPaintingFrameVariant;
+}
+
+export interface WallPaintingMountPose {
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly rotation: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly wallAxis: 'x' | 'z';
+  readonly outwardNormal: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly offsetDirection: 1 | -1;
 }
 
 export interface WallPaintingsBuild {
@@ -161,6 +183,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     floor: 'upper',
     room: 'loft library',
     wallOrientation: 'west',
+    surfaceSide: 'negative',
     position: { x: 4.08, z: -3.2 },
     size: 1.9,
     frame: {
@@ -329,7 +352,9 @@ function addFrameRails(
   });
 }
 
-function placeOnWall(group: Group, config: WallPaintingConfig): void {
+export function resolveWallPaintingMountPose(
+  config: WallPaintingConfig
+): WallPaintingMountPose {
   const baseCenterY =
     config.floor === 'upper'
       ? UPPER_PAINTING_CENTER_Y
@@ -337,20 +362,40 @@ function placeOnWall(group: Group, config: WallPaintingConfig): void {
   const centerY = baseCenterY + (config.position.y ?? 0);
   const backingDepth = config.frame.backingDepth ?? DEFAULT_BACKING_DEPTH;
   const wallOffset = WALL_OFFSET + backingDepth / 2;
+  const offsetDirection = config.surfaceSide === 'negative' ? -1 : 1;
 
   if (config.wallOrientation === 'west') {
-    group.position.set(
-      config.position.x + wallOffset,
-      centerY,
-      config.position.z
-    );
-    group.rotation.y = Math.PI / 2;
-    return;
+    const rotationY = offsetDirection > 0 ? Math.PI / 2 : -Math.PI / 2;
+    return {
+      position: {
+        x: config.position.x + wallOffset * offsetDirection,
+        y: centerY,
+        z: config.position.z,
+      },
+      rotation: { x: 0, y: rotationY, z: 0 },
+      wallAxis: 'x',
+      outwardNormal: { x: offsetDirection, y: 0, z: 0 },
+      offsetDirection,
+    };
   }
 
-  group.position.set(
-    config.position.x,
-    centerY,
-    config.position.z + wallOffset
-  );
+  const rotationY = offsetDirection > 0 ? 0 : Math.PI;
+  return {
+    position: {
+      x: config.position.x,
+      y: centerY,
+      z: config.position.z + wallOffset * offsetDirection,
+    },
+    rotation: { x: 0, y: rotationY, z: 0 },
+    wallAxis: 'z',
+    outwardNormal: { x: 0, y: 0, z: offsetDirection },
+    offsetDirection,
+  };
+}
+
+function placeOnWall(group: Group, config: WallPaintingConfig): void {
+  const pose = resolveWallPaintingMountPose(config);
+
+  group.position.set(pose.position.x, pose.position.y, pose.position.z);
+  group.rotation.set(pose.rotation.x, pose.rotation.y, pose.rotation.z);
 }


### PR DESCRIPTION
### Motivation
- The upstairs `3d-printer-loft-library-west` painting was rendering as an empty frame because the image plane was mounted facing the wrong side of the partition and culled from the camera view.  
- Mounting logic assumed a single positive-side orientation for west/north walls which prevented per-painting control of the image facing direction.

### Description
- Add an optional `surfaceSide?: 'positive' | 'negative'` to `WallPaintingConfig` and export a pure helper `resolveWallPaintingMountPose(config)` that returns resolved position, rotation, wall axis, outward normal, and offset direction. (`src/scene/structures/wallPaintings.ts`).
- Use the resolver inside `placeOnWall()` to apply mount poses and preserve previous defaults for existing paintings. (`placeOnWall` now uses `resolveWallPaintingMountPose`).
- Set only `3d-printer-loft-library-west` to `surfaceSide: 'negative'` so the image plane is mounted on the interior (negative-X) side and faces -X while keeping its intended wall/area. (`src/scene/structures/wallPaintings.ts`).
- Add regression tests that validate mount poses, normals, and visible render parts (backing, mat, image plane, and four rails) and assert the 3D-printer painting faces -X; also mock image loading for tests. (`src/scene/structures/__tests__/wallPaintings.test.ts`).
- Refresh miniature proxy metadata to acknowledge the source-only change by bumping `syncRevision`/`syncNote` and updating the generated manifest. (`src/scene/miniature/sceneComponentRegistry.ts`, `src/scene/miniature/miniatureManifest.generated.json`).

### Testing
- Ran formatting: `npm run format:write` — succeeded.  
- Ran lint: `npm run lint` — succeeded.  
- Ran unit tests: `npm run test:ci` — initially failed due to a stale miniature manifest, then after updating the miniature registry/manifest reran `npm run test:ci` and all tests passed (`183 files`, `1469 tests` passed).  
- Ran docs check: `npm run docs:check` — passed (link-check produced external fetch warnings but completed successfully).  
- Built and smoke-tested: `npm run build` and `npm run smoke` — both succeeded.  
- Notes: the fix intentionally avoids `DoubleSide` materials and is data-driven (only the 3D-printer painting uses `surfaceSide: 'negative'`) to preserve other paintings and avoid hiding real mounting regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fbcf8354832f883b7ae9e98e2d8e)