### PR TITLE
🖼️ : – fix 3D-printer wall painting

### DIFF
--- a/src/scene/miniature/miniatureManifest.generated.json
+++ b/src/scene/miniature/miniatureManifest.generated.json
@@ -449,11 +449,11 @@
       "id": "decor:wall-paintings",
       "sourceFiles": ["src/scene/structures/wallPaintings.ts"],
       "proxyFiles": ["src/scene/miniature/sceneComponentRegistry.ts"],
-      "syncRevision": 8,
-      "syncNote": "Wall-painting API cleanup keeps the same representative tabletop proxy geometry.",
-      "sourceFingerprint": "06ac3d14e53d098f7583918a19563c1b78166069f540e232ba8ab73d4667c3f8",
+      "syncRevision": 10,
+      "syncNote": "3D-printer wall-painting mount-side fix keeps the same tabletop proxy geometry.",
+      "sourceFingerprint": "e0e3fbc33eeb9b8a2d301ccf1dd3a8c55d6c4d4bb0c366e718cb8dae79acd184",
       "proxyFingerprint": "5386be0067a60fb1d8f8ec045356b9824019e94d03bc2c6bd0db200878b43f4b",
-      "metadataFingerprint": "2bcc02f8f0a71e3f95f9bdda15b0cf21f9cb1ef8f24ace7bf5b08566db87dde7"
+      "metadataFingerprint": "3d35b18b088a00cb2ca994fd11b1e56a41546d18e959390b47f12285b6ddea7a"
     },
     {
       "id": "environment:backyard",

--- a/src/scene/miniature/sceneComponentRegistry.ts
+++ b/src/scene/miniature/sceneComponentRegistry.ts
@@ -84,9 +84,9 @@ export const MINIATURE_SCENE_COMPONENT_COVERAGE = [
     kind: 'proxy',
     sourceFiles: ['src/scene/structures/wallPaintings.ts'],
     proxyFiles: [SELF_FILE],
-    syncRevision: 8,
+    syncRevision: 10,
     syncNote:
-      'Wall-painting API cleanup keeps the same representative tabletop proxy geometry.',
+      '3D-printer wall-painting mount-side fix keeps the same tabletop proxy geometry.',
   },
   {
     id: 'decor:lower-floor-furnishings',

--- a/src/scene/structures/__tests__/wallPaintings.test.ts
+++ b/src/scene/structures/__tests__/wallPaintings.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { Mesh, Texture, TextureLoader, Vector3 } from 'three';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from '../lowerFloorFurnishings';
-import { WALL_PAINTING_CONFIGS, getFurnishingCenter } from '../wallPaintings';
+import {
+  WALL_PAINTING_CONFIGS,
+  createWallPaintings,
+  getFurnishingCenter,
+  resolveWallPaintingMountPose,
+} from '../wallPaintings';
 
 const EXPECTED_IMAGE_PATHS = [
   '/images/3dprinted_rocket_nosecone.jpg',
@@ -12,7 +18,21 @@ const EXPECTED_IMAGE_PATHS = [
   '/images/launch.jpg',
 ] as const;
 
+const REQUIRED_PARTS = [
+  'backing',
+  'mat',
+  'image',
+  'left-rail',
+  'right-rail',
+  'top-rail',
+  'bottom-rail',
+] as const;
+
 describe('WALL_PAINTING_CONFIGS', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('places exactly one painting for each public image asset', () => {
     expect(WALL_PAINTING_CONFIGS).toHaveLength(EXPECTED_IMAGE_PATHS.length);
     expect(
@@ -70,5 +90,116 @@ describe('WALL_PAINTING_CONFIGS', () => {
 
     expect(variants.size).toBeGreaterThan(1);
     expect(WALL_PAINTING_CONFIGS.every((config) => config.size > 0)).toBe(true);
+  });
+
+  it('resolves each painting to a visible wall-mounted pose on its wall axis', () => {
+    WALL_PAINTING_CONFIGS.forEach((config) => {
+      const pose = resolveWallPaintingMountPose(config);
+      const normalLength = Math.hypot(
+        pose.outwardNormal.x,
+        pose.outwardNormal.y,
+        pose.outwardNormal.z
+      );
+
+      expect(['x', 'z']).toContain(pose.wallAxis);
+      expect(normalLength).toBeGreaterThan(0);
+      expect(pose.outwardNormal.y).toBe(0);
+
+      if (config.wallOrientation === 'west') {
+        expect(pose.wallAxis).toBe('x');
+        expect(pose.position.z).toBeCloseTo(config.position.z);
+        expect(pose.outwardNormal.x).toBe(pose.offsetDirection);
+        expect(pose.outwardNormal.z).toBe(0);
+        expect(Math.sign(pose.position.x - config.position.x)).toBe(
+          pose.offsetDirection
+        );
+      } else {
+        expect(pose.wallAxis).toBe('z');
+        expect(pose.position.x).toBeCloseTo(config.position.x);
+        expect(pose.outwardNormal.x).toBe(0);
+        expect(pose.outwardNormal.z).toBe(pose.offsetDirection);
+        expect(Math.sign(pose.position.z - config.position.z)).toBe(
+          pose.offsetDirection
+        );
+      }
+    });
+  });
+
+  it('builds backing, mat, image plane, and four frame rails for every painting', () => {
+    vi.spyOn(TextureLoader.prototype, 'load').mockImplementation((path) => {
+      const texture = new Texture();
+      texture.name = `MockTexture:${String(path)}`;
+      return texture;
+    });
+
+    const build = createWallPaintings();
+    const paintings = [
+      ...build.groundGroup.children,
+      ...build.upperGroup.children,
+    ];
+
+    expect(paintings).toHaveLength(WALL_PAINTING_CONFIGS.length);
+
+    paintings.forEach((painting) => {
+      REQUIRED_PARTS.forEach((partName) => {
+        const part = painting.getObjectByName(`${painting.name}:${partName}`);
+        expect(part, `${painting.name} missing ${partName}`).toBeInstanceOf(
+          Mesh
+        );
+      });
+    });
+
+    build.dispose();
+  });
+
+  it('keeps each image plane in front of its backing on the resolved outward side', () => {
+    vi.spyOn(TextureLoader.prototype, 'load').mockReturnValue(new Texture());
+
+    const build = createWallPaintings();
+    const worldNormal = new Vector3();
+    const expectedNormal = new Vector3();
+
+    WALL_PAINTING_CONFIGS.forEach((config) => {
+      const floorGroup =
+        config.floor === 'upper' ? build.upperGroup : build.groundGroup;
+      const painting = floorGroup.getObjectByName(`WallPainting:${config.id}`)!;
+      const backing = painting.getObjectByName(`${painting.name}:backing`)!;
+      const image = painting.getObjectByName(`${painting.name}:image`)!;
+      const pose = resolveWallPaintingMountPose(config);
+
+      image.getWorldPosition(worldNormal);
+      backing.getWorldPosition(expectedNormal);
+      worldNormal.sub(expectedNormal);
+      expectedNormal.set(
+        pose.outwardNormal.x,
+        pose.outwardNormal.y,
+        pose.outwardNormal.z
+      );
+
+      expect(worldNormal.dot(expectedNormal)).toBeGreaterThan(0);
+      const resolvedImageNormal = new Vector3(0, 0, 1).applyEuler(
+        painting.rotation
+      );
+      expect(resolvedImageNormal.x).toBeCloseTo(expectedNormal.x);
+      expect(resolvedImageNormal.y).toBeCloseTo(expectedNormal.y);
+      expect(resolvedImageNormal.z).toBeCloseTo(expectedNormal.z);
+    });
+
+    build.dispose();
+  });
+
+  it('mounts the upstairs 3D-printer image on the negative-X side of its interior wall', () => {
+    const printerPainting = WALL_PAINTING_CONFIGS.find(
+      (config) => config.id === '3d-printer-loft-library-west'
+    )!;
+    const pose = resolveWallPaintingMountPose(printerPainting);
+
+    expect(printerPainting.imagePath).toBe('/images/3dprinter.jpg');
+    expect(printerPainting.wallOrientation).toBe('west');
+    expect(printerPainting.surfaceSide).toBe('negative');
+    expect(pose.wallAxis).toBe('x');
+    expect(pose.outwardNormal).toEqual({ x: -1, y: 0, z: 0 });
+    expect(pose.position.x).toBeLessThan(printerPainting.position.x);
+    expect(pose.rotationY).toBeCloseTo(-Math.PI / 2);
   });
 });

--- a/src/scene/structures/wallPaintings.ts
+++ b/src/scene/structures/wallPaintings.ts
@@ -18,6 +18,7 @@ import { DEFAULT_LOWER_FLOOR_FURNISHINGS } from './lowerFloorFurnishings';
 
 export type WallPaintingFloor = 'ground' | 'upper';
 export type WallPaintingOrientation = 'north' | 'west';
+export type WallPaintingSurfaceSide = 'positive' | 'negative';
 
 export interface WallPaintingFrameVariant {
   readonly frameColor: ColorRepresentation;
@@ -35,6 +36,7 @@ export interface WallPaintingConfig {
   readonly floor: WallPaintingFloor;
   readonly room: string;
   readonly wallOrientation: WallPaintingOrientation;
+  readonly surfaceSide?: WallPaintingSurfaceSide;
   readonly position: {
     readonly x: number;
     // Optional additive offset from the floor's default painting center height.
@@ -43,6 +45,22 @@ export interface WallPaintingConfig {
   };
   readonly size: number;
   readonly frame: WallPaintingFrameVariant;
+}
+
+export interface WallPaintingMountPose {
+  readonly position: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly rotationY: number;
+  readonly wallAxis: 'x' | 'z';
+  readonly outwardNormal: {
+    readonly x: number;
+    readonly y: number;
+    readonly z: number;
+  };
+  readonly offsetDirection: 1 | -1;
 }
 
 export interface WallPaintingsBuild {
@@ -162,6 +180,7 @@ export const WALL_PAINTING_CONFIGS: readonly WallPaintingConfig[] = [
     room: 'loft library',
     wallOrientation: 'west',
     position: { x: 4.08, z: -3.2 },
+    surfaceSide: 'negative',
     size: 1.9,
     frame: {
       frameColor: 0x2f3033,
@@ -329,7 +348,9 @@ function addFrameRails(
   });
 }
 
-function placeOnWall(group: Group, config: WallPaintingConfig): void {
+export function resolveWallPaintingMountPose(
+  config: WallPaintingConfig
+): WallPaintingMountPose {
   const baseCenterY =
     config.floor === 'upper'
       ? UPPER_PAINTING_CENTER_Y
@@ -337,20 +358,37 @@ function placeOnWall(group: Group, config: WallPaintingConfig): void {
   const centerY = baseCenterY + (config.position.y ?? 0);
   const backingDepth = config.frame.backingDepth ?? DEFAULT_BACKING_DEPTH;
   const wallOffset = WALL_OFFSET + backingDepth / 2;
+  const offsetDirection = config.surfaceSide === 'negative' ? -1 : 1;
 
   if (config.wallOrientation === 'west') {
-    group.position.set(
-      config.position.x + wallOffset,
-      centerY,
-      config.position.z
-    );
-    group.rotation.y = Math.PI / 2;
-    return;
+    return {
+      position: {
+        x: config.position.x + wallOffset * offsetDirection,
+        y: centerY,
+        z: config.position.z,
+      },
+      rotationY: offsetDirection === 1 ? Math.PI / 2 : -Math.PI / 2,
+      wallAxis: 'x',
+      outwardNormal: { x: offsetDirection, y: 0, z: 0 },
+      offsetDirection,
+    };
   }
 
-  group.position.set(
-    config.position.x,
-    centerY,
-    config.position.z + wallOffset
-  );
+  return {
+    position: {
+      x: config.position.x,
+      y: centerY,
+      z: config.position.z + wallOffset * offsetDirection,
+    },
+    rotationY: offsetDirection === 1 ? 0 : Math.PI,
+    wallAxis: 'z',
+    outwardNormal: { x: 0, y: 0, z: offsetDirection },
+    offsetDirection,
+  };
+}
+
+function placeOnWall(group: Group, config: WallPaintingConfig): void {
+  const pose = resolveWallPaintingMountPose(config);
+  group.position.set(pose.position.x, pose.position.y, pose.position.z);
+  group.rotation.y = pose.rotationY;
 }


### PR DESCRIPTION
### Motivation
- The upstairs `/images/3dprinter.jpg` painting rendered as an empty/dark frame because the image and mat (plane geometries) were mounted facing the wrong side of the interior west wall.\
- Fix the mount-side logic so the image plane faces the camera-visible side of the interior partition without moving other paintings or changing assets.\

### Description
- Added an optional `surfaceSide?: 'positive' | 'negative'` to `WallPaintingConfig` and a pure resolver `resolveWallPaintingMountPose(config)` that returns position, `rotationY`, `wallAxis`, outward normal, and `offsetDirection`.\
- Updated `placeOnWall()` to use the new resolver and set only `3d-printer-loft-library-west` to `surfaceSide: 'negative'` so its image faces -X (interior wall side) while preserving all other placements.\
- Kept geometry/visual structure unchanged (backing, mat, image planes and frame rails remain) and avoided `DoubleSide` fixes, addressing the culling/mount-side root cause.\
- Bumped the `decor:wall-paintings` `syncRevision` and `syncNote` in the miniature registry/manifest to acknowledge the source change while tabletop proxy geometry remains unchanged.\

### Testing
- Ran formatting and lint: `npm run format:write` (passed) and `npm run lint` (passed).\
- Ran unit tests: `npm run test:ci` including the new/updated `src/scene/structures/__tests__/wallPaintings.test.ts` and all suites (final run: 183 files, all tests passed).\
- Refreshed miniature manifest: `npm run miniature:manifest:update` and updated `src/scene/miniature/sceneComponentRegistry.ts` (syncRevision and syncNote) per the manifest check (passed).\
- Ran docs and build checks: `npm run docs:check` (passed with external-link warnings) and `npm run build` + `npm run smoke` (passed).\
- Started dev preview: `npm run dev -- --host 127.0.0.1` (Vite started successfully at `http://127.0.0.1:5173/`; the interactive run was intentionally timed out in CI).\

Residual risk / follow-up: visually verify in the immersive preview at `/?mode=immersive&disablePerformanceFailover=1` by going upstairs near the x≈4 interior wall to confirm `/images/3dprinter.jpg` appears inside its frame; no asset renames or binary changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45fbebf154832fb5f6a819804e405f)